### PR TITLE
Bump Redis to major version 8 (safe subset of #156)

### DIFF
--- a/authentik/kustomization.yaml
+++ b/authentik/kustomization.yaml
@@ -21,7 +21,7 @@ images:
   - name: quay.io/prometheuscommunity/postgres-exporter
     newTag: "v0.19.1"
   - name: redis
-    newTag: "7.4-alpine"
+    newTag: "8.6-alpine"
 
 helmCharts:
   - name: authentik

--- a/intelowl/kustomization.yaml
+++ b/intelowl/kustomization.yaml
@@ -30,7 +30,7 @@ images:
   - name: postgres
     newTag: "16-alpine"
   - name: redis
-    newTag: "6.2.21-alpine"
+    newTag: "8.6.2-alpine"
   - name: rabbitmq
     newTag: "3.13-alpine"
   - name: busybox

--- a/mastodon-stack/kustomization.yaml
+++ b/mastodon-stack/kustomization.yaml
@@ -28,7 +28,7 @@ images:
   - name: postgres
     newTag: "15"
   - name: redis
-    newTag: "7"
+    newTag: "8"
   - name: quay.io/prometheuscommunity/postgres-exporter
     newTag: "v0.19.1"
   - name: oliver006/redis_exporter

--- a/yeti/kustomization.yaml
+++ b/yeti/kustomization.yaml
@@ -28,6 +28,6 @@ images:
   - name: arangodb
     newTag: "3.12.9"
   - name: redis
-    newTag: "7.4-alpine"
+    newTag: "8.6-alpine"
   - name: busybox
     newTag: "1.37"


### PR DESCRIPTION
## Summary
Safe subset of Renovate PR #156. Only Redis instances **without persistent volumes** — no data migration needed.

- **authentik**: 7.4-alpine → 8.6-alpine (cache only)
- **mastodon-stack**: 7 → 8 (cache only)
- **yeti**: 7.4-alpine → 8.6-alpine (cache only)
- **intelowl**: 6.2.21-alpine → 8.6.2-alpine (cache only)

### Excluded from this PR
| Change | Reason |
|--------|--------|
| All Postgres 14/15/16 → 18 | Major version bump requires `pg_dump`/`pg_restore` per instance — data directory format incompatible |
| matrix-stack Redis 8 → 8.6 | Has a 10Gi PVC — take Velero snapshot before bumping |
| intelowl RabbitMQ 3.13 → 4.2 | Major rewrite (Khepri replaces Mnesia) — needs app compatibility testing |

## Test plan
- [x] Verify authentik login still works after Redis restart
- [x] Verify Mastodon timeline/streaming functional
- [x] Verify Yeti API responds
- [x] Verify IntelOwl analysis jobs complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)