### PR TITLE
envoy-gateway: unpin from rke2-node-15 (data-plane + controller)

### DIFF
--- a/envoy-gateway-system/kustomization.yaml
+++ b/envoy-gateway-system/kustomization.yaml
@@ -3,14 +3,3 @@ kind: Kustomization
 
 resources:
   - install.yaml
-
-patches:
-  - target:
-      kind: Deployment
-      name: envoy-gateway
-      namespace: envoy-gateway-system
-    patch: |-
-      - op: add
-        path: /spec/template/spec/nodeSelector
-        value:
-          kubernetes.io/hostname: rke2-node-15

--- a/envoy-gateway/10-envoy-proxy.yaml
+++ b/envoy-gateway/10-envoy-proxy.yaml
@@ -7,10 +7,6 @@ spec:
   provider:
     type: Kubernetes
     kubernetes:
-      envoyDeployment:
-        pod:
-          nodeSelector:
-            kubernetes.io/hostname: rke2-node-15
       envoyService:
         type: LoadBalancer
         annotations:


### PR DESCRIPTION
## Summary
- Removes the `kubernetes.io/hostname: rke2-node-15` nodeSelector from the EnvoyProxy data-plane (`envoy-gateway/10-envoy-proxy.yaml`) and from the envoy-gateway controller (`envoy-gateway-system/kustomization.yaml`).
- Pinning both pods to a single node means any node-15 outage takes down `:443` for every `*.white.fm`, `*.whitematter.tech`, and `*.w3rdw.radio` host. It also breaks cloudflared-tunneled services (grafana etc.) since they upstream into this same gateway.
- Currently triggering an outage: node-15 down → envoy-proxy stuck Pending → `headscale.white.fm:443` unreachable → tailnet auth dead.

## Test plan
- [ ] Merge; watch ArgoCD sync envoy-gateway / envoy-gateway-system apps
- [ ] `kubectl -n envoy-gateway-system get pods -o wide` — both deployments scheduled on any Ready node
- [ ] `curl -sk https://headscale.white.fm/health` returns 200
- [ ] `curl -sk https://grafana.white.fm/` returns Grafana login
- [ ] Mac: `tailscale up --login-server=https://headscale.white.fm --accept-routes` succeeds