### PR TITLE
dns: route derp.white.fm to DERP's own VIP, not the envoy wildcard

### DIFF
--- a/dns/ebl-amazonaws.yaml
+++ b/dns/ebl-amazonaws.yaml
@@ -5,6 +5,19 @@ metadata:
   namespace: kube-system
 data:
   white-fm.conf: |
+    # derp.white.fm has its own MetalLB VIP (the DERP service on 10.99.5.101),
+    # NOT the envoy gateway. The wildcard template below would otherwise point
+    # the in-cluster tailscale-router at envoy, which doesn't speak the DERP
+    # protocol -> tailnet relay times out -> MagicDNS / *.internal.white.fm
+    # break for tailscale clients. Override before the wildcard catches it.
+    derp.white.fm:53 {
+        errors
+        cache 30
+        hosts {
+            10.99.5.101 derp.white.fm
+            fallthrough
+        }
+    }
     # *.white.fm wildcard answers locally — every public *.white.fm hostname
     # this cluster runs lands on the envoy gateway VIP anyway, so cluster pods
     # don't need to recurse out and back through the WAN.


### PR DESCRIPTION
## Summary
- Add a CoreDNS server block for `derp.white.fm` that returns `10.99.5.101` (the DERP service LB IP) before the catch-all `*.white.fm -> 10.99.5.110` template fires.
- The wildcard template assumed every public `*.white.fm` hostname terminates on the envoy gateway VIP. That's true for HTTP services, but DERP has its own MetalLB LB on `10.99.5.101` and uses non-HTTP ports (8443, 3478). Sending the in-cluster `tailscale-router` to envoy at `:8443` produced `derp.Recv: context deadline exceeded`, breaking tailnet relay -> MagicDNS / `*.internal.white.fm` resolution for tailscale clients.
- Externally `derp.white.fm` resolves to the WAN IP via Cloudflare DNS and UniFi port-forward; this override only affects in-cluster queries.

## Test plan
- [ ] Merge and let ArgoCD sync the `dns` app
- [ ] CoreDNS picks up the new file (the `reload` plugin is enabled; bounce the deployment if needed)
- [ ] `kubectl run dnsprobe --rm -i --restart=Never --image=busybox:1.37 -- nslookup derp.white.fm 10.43.0.10` returns `10.99.5.101`
- [ ] `kubectl -n headscale logs deployment/tailscale-router | tail -20` no longer shows `context deadline exceeded` for `derp-900`
- [ ] Re-init Mac tailscale: `tailscale up --login-server=https://headscale.white.fm --accept-routes` connects and resolves `*.internal.white.fm`