### PR TITLE
astronomy: switch image refs to registry.internal.white.fm (HTTPS)

### DIFF
--- a/astronomy/10-deployment-api.yaml
+++ b/astronomy/10-deployment-api.yaml
@@ -19,7 +19,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: astronomy-api
-          image: registry.white.fm/astronomy-api
+          image: registry.internal.white.fm/astronomy-api
           ports:
             - containerPort: 8000
               name: http

--- a/astronomy/11-deployment-ui.yaml
+++ b/astronomy/11-deployment-ui.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: astronomy-ui
-          image: registry.white.fm/astronomy-ui
+          image: registry.internal.white.fm/astronomy-ui
           ports:
             - containerPort: 8080
               name: http

--- a/astronomy/kustomization.yaml
+++ b/astronomy/kustomization.yaml
@@ -18,7 +18,7 @@ generators:
   - ksops.yaml
 
 images:
-  - name: registry.white.fm/astronomy-api
+  - name: registry.internal.white.fm/astronomy-api
     newTag: "1.0.13"
-  - name: registry.white.fm/astronomy-ui
+  - name: registry.internal.white.fm/astronomy-ui
     newTag: "1.1.14"


### PR DESCRIPTION
## Summary
- Commit `7141bd0b` removed the public `registry.white.fm` HTTPRoute. Astronomy redeploy (UI 1.1.14) then failed with ImagePullBackOff on every node.
- Switch image refs to `registry.internal.white.fm` — already has an HTTPRoute on the `https-internal-white-fm` listener with the `wildcard-white-fm-tls` cert, backed by the same `registry.registry.svc:5000` Service. LAN/tailnet only, no public exposure.
- Verified from an in-cluster pod: `v2/`, `tags/list`, and `manifests/1.0.13` all return 200 over HTTPS.

## Test plan
- [ ] ArgoCD syncs astronomy
- [ ] `astronomy-api` and `astronomy-ui` pods reach Ready (no more ImagePullBackOff)
- [ ] `astronomy.white.fm` returns 200 (Envoy upstream stops returning connection refused)