### PR TITLE
astronomy: deploy images from ghcr (RobertDWhite/astronomy)

### DIFF
--- a/astronomy/kustomization.yaml
+++ b/astronomy/kustomization.yaml
@@ -19,6 +19,8 @@ generators:
 
 images:
   - name: registry.internal.white.fm/astronomy-api
-    newTag: "1.0.16"
+    newName: ghcr.io/robertdwhite/astronomy-api
+    newTag: sha-07bdb6a2770580f9874b5332fb8aa1f5a113962f
   - name: registry.internal.white.fm/astronomy-ui
-    newTag: "1.1.17"
+    newName: ghcr.io/robertdwhite/astronomy-ui
+    newTag: sha-07bdb6a2770580f9874b5332fb8aa1f5a113962f


### PR DESCRIPTION
Repoint the astronomy app to images built by the new **RobertDWhite/astronomy**
repo (extracted app source + GitHub Actions CI), instead of the manually-pushed
in-cluster registry images.

- `registry.internal.white.fm/astronomy-{api,ui}` → `ghcr.io/robertdwhite/astronomy-{api,ui}`
- Pinned to the immutable tag `sha-07bdb6a2770580f9874b5332fb8aa1f5a113962f`
  (the commit that built them). Renovate/image-updater can bump it later.

### ⚠ Merge gate — do this first
The two ghcr packages are currently **private**; the cluster pulls anonymously,
so flip both to **public** before merging or astronomy pods will fail ImagePull:
- https://github.com/users/RobertDWhite/packages/container/astronomy-api/settings
- https://github.com/users/RobertDWhite/packages/container/astronomy-ui/settings

(Package settings → Danger Zone → Change visibility → Public.) After merge,
ArgoCD auto-syncs astronomy to the ghcr images.

### Notes
- The pilot caught a latent break: the API Dockerfile had been Renovate-bumped to
  `python:3.14-slim`, which can't build `ephem` (no wheel, no compiler). Fixed to
  `python:3.12-slim` in the new repo.
- `astronomy/api` and `astronomy/ui` were **gitignored** in this repo (never
  tracked — `*.py`/`*.ts`/`*.tsx`/`*.txt` are globally ignored), so they don't
  appear in this diff. That source now lives, version-controlled, in
  RobertDWhite/astronomy. The local working-tree copies can be deleted whenever.