### PR TITLE
astronomy: multi-arch ghcr images, pinned by digest

### DIFF
--- a/astronomy/kustomization.yaml
+++ b/astronomy/kustomization.yaml
@@ -20,7 +20,7 @@ generators:
 images:
   - name: registry.internal.white.fm/astronomy-api
     newName: ghcr.io/robertdwhite/astronomy-api
-    newTag: sha-07bdb6a2770580f9874b5332fb8aa1f5a113962f
+    digest: sha256:3751a8b538c9be4ac30ac1383c6744aa8819249893878f191b9422f4df099355
   - name: registry.internal.white.fm/astronomy-ui
     newName: ghcr.io/robertdwhite/astronomy-ui
-    newTag: sha-07bdb6a2770580f9874b5332fb8aa1f5a113962f
+    digest: sha256:041f7c581c2a4729b6603d8af32f3b35f209de4852173e6b8da5702d90384392


### PR DESCRIPTION
Follow-up to #427. After that merged, the new astronomy-api pod landed on an
**arm64** node (`rke2-node-10`) and hit `ImagePullBackOff: no match for platform
in manifest` — the ghcr images were built amd64-only.

Fixes (in RobertDWhite/astronomy):
- CI now builds **multi-arch** `linux/amd64,linux/arm64` (added QEMU).
- UI Dockerfile installs the rollup native binary matching the target arch
  (the hardcoded x64 binary broke the arm64 build).

This PR repoints the kustomization to the resulting **multi-arch index digests**
instead of tags:
- `astronomy-api@sha256:3751a8b5…`
- `astronomy-ui@sha256:041f7c58…`

Pinning by digest also makes astronomy compliant with the `require-image-digest`
(H6) Kyverno policy (the old tag pin was an audit violation). No registry-policy
change needed — `ghcr.io/robertdwhite/*` is already allowlisted.

After merge, ArgoCD syncs and the api pod will pull successfully on arm64.