### PR TITLE
mcp servers: congress/jetlog/monica → ghcr (digest-pinned)

### DIFF
--- a/congress-mcp/kustomization.yaml
+++ b/congress-mcp/kustomization.yaml
@@ -12,4 +12,5 @@ generators:
 
 images:
   - name: registry.internal.white.fm/congress-mcp
-    newTag: "0.1.0"
+    newName: ghcr.io/robertdwhite/congress-mcp
+    digest: sha256:02c2339815a41249dfef76598b1d17bae83cda912f5f609c13c44f94dae6ec04

--- a/mcp/jetlog/kustomization.yaml
+++ b/mcp/jetlog/kustomization.yaml
@@ -12,4 +12,5 @@ generators:
 
 images:
   - name: registry.internal.white.fm/jetlog-mcp
-    newTag: "0.1.0"
+    newName: ghcr.io/robertdwhite/jetlog-mcp
+    digest: sha256:b2f04f25f2459a3a150988f9b7706cf8d05b75f0f5b4b11d49bf6665e532d42b

--- a/mcp/monica/kustomization.yaml
+++ b/mcp/monica/kustomization.yaml
@@ -12,5 +12,5 @@ generators:
 
 images:
   - name: registry.internal.white.fm/monica-mcp
-    newTag: "0.1.0"
-    digest: "sha256:ad28659c5584d442b8faa255015dccd14668325028691f803f82530c2f8b1bb7"
+    newName: ghcr.io/robertdwhite/monica-mcp
+    digest: sha256:926a34c1c2922bb4345c93392337407f103566fa0353522cb916ab950e7ba4ed


### PR DESCRIPTION
Batch cutover for 3 of the 4 extracted MCP servers (all public repos +
public ghcr packages, anonymously pullable — verified):

- congress-mcp → `ghcr.io/robertdwhite/congress-mcp@sha256:02c23398…`
- jetlog-mcp  → `ghcr.io/robertdwhite/jetlog-mcp@sha256:b2f04f25…`
- monica-mcp  → `ghcr.io/robertdwhite/monica-mcp@sha256:926a34c1…`

Images are multi-arch (amd64+arm64) and pinned by index digest. Source now lives
in RobertDWhite/<app>; manifests stay here.

**media-mcp is intentionally excluded** — its package is private, so it needs a
pull secret (or a public package) before cutover. Handled separately.