### PR TITLE
media-mcp: private ghcr image + pull secret

### DIFF
--- a/media-mcp/13-ghcr-pull.sops.yaml
+++ b/media-mcp/13-ghcr-pull.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: ghcr-pull
+    namespace: media-mcp
+type: kubernetes.io/dockerconfigjson
+stringData:
+    .dockerconfigjson: ENC[AES256_GCM,data:BelWxQy2onwVb+KW203yLjEDv2MSOypWW/m9egVH5ZTh30tWnKjkwu1QgqAupSYA7e0enx+RKz9+RZYA/jPQbA3lP93ucijMIcYGQJwrQvbP1PviYTjKLXn3KrMpCT//Q7Yhxi/M2O/kenbGUXGEig8CdHUalJHYpH9yZdgQMmtGPC+0yhbPrnVGCmMuucezEA5w+an14mVVk3GgvfQaRlDSkTr+LgsnNjbV+JhYY5YxOcqE/4hgtT2Eq128eq8O,iv:ck/87VCEQi7XMdLKumfYTAzaRzG0erygB9kTmn/C53Y=,tag:G3XFl1jdB6u8Vv4yVys5Xw==,type:str]
+sops:
+    age:
+        - recipient: age16krjysalsq26mfndnthd9r42thapj43a0zdndgrrz30utzuhwd0q7fxh9p
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxZVlxTjZiQjQvWXU3cUY0
+            VnBXU1BpS1ZRczZMV0JMYjBQWElyckhZdTBZCkZBSDU0d3F5VHh3MEY0bzVIc21E
+            c1NzRFh3SkN0WGFrN1RrKytqQU5wV3cKLS0tIGFHSjZMbGVnRGt3UGFFQnlhVXI3
+            NjIyRmJJam1RbmVSakVRb0Fva2R4eEkKjlYzDkbYM3R3lqgvfanRHCTl4Z9RodHv
+            2x+DXh1xQaer57qzR3JZk7l8nME5KDdwDfYRjv9UQmRTgzNSKZ7qPQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-02T19:43:43Z"
+    mac: ENC[AES256_GCM,data:4z3N+YZ+m3BYoi0iRmToVkd23V/tPy0lzfrFxozoo5dcvttZAO7b0CY0LWNrb82/2bltJ6QJ7E7NAYhPk7/IswjOL4ySo/UPwWF9Y4gyeNNYwi7Vc7eRBbbEDd0SJ2fULwSP6FB/RyW/m8u8HIAc0uD8g4ZbVsD344Ns9lkFE/A=,iv:PVYnIlaksr7XueoE5wsGNgw2/fe4A47r6vo2YHFDG3E=,tag:yZiqYIf3qczyNwJH7aQywA==,type:str]
+    encrypted_regex: ^(data|stringData|parameters)$
+    version: 3.10.2

--- a/media-mcp/20-deployment.yaml
+++ b/media-mcp/20-deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: media-mcp
     spec:
+      imagePullSecrets:
+        - name: ghcr-pull
       nodeSelector:
         kubernetes.io/arch: amd64
       securityContext:

--- a/media-mcp/ksops.yaml
+++ b/media-mcp/ksops.yaml
@@ -8,3 +8,4 @@ metadata:
         path: ksops
 files:
   - 11-secret.sops.yaml
+  - 13-ghcr-pull.sops.yaml

--- a/media-mcp/kustomization.yaml
+++ b/media-mcp/kustomization.yaml
@@ -13,4 +13,5 @@ generators:
 
 images:
   - name: registry.internal.white.fm/media-mcp
-    newTag: "0.2.0"
+    newName: ghcr.io/robertdwhite/media-mcp
+    digest: sha256:f51447cc03c6bb6847e8c862ee8675689b7166a31c0173757caff20749749734


### PR DESCRIPTION
Cutover for media-mcp (kept fully private per request).

- Source in **RobertDWhite/media-mcp** (private), multi-arch CI -> ghcr.
- New `ghcr-pull` dockerconfigjson Secret, **SOPS-encrypted** (read:packages
  classic token), generated via KSOPS; `imagePullSecrets` added to the
  deployment so the node can pull the private image.
- Image -> `ghcr.io/robertdwhite/media-mcp@sha256:f51447cc…` (digest-pinned).

Token was never committed in plaintext or echoed; only the encrypted blob is in
git. Verified the token pulls the image (HTTP 200) before wiring.