### PR TITLE
appstore-reviews: app/ui -> ghcr (digest-pinned)

### DIFF
--- a/appstore-reviews/kustomization.yaml
+++ b/appstore-reviews/kustomization.yaml
@@ -17,8 +17,8 @@ generators:
 
 images:
   - name: registry.internal.white.fm/appstore-app
-    newName: registry.internal.white.fm/appstore-app
-    newTag: "0.1.0"
+    newName: ghcr.io/robertdwhite/appstore-app
+    digest: sha256:908ef0f987c768895a0fef15f97ec260ffe712febe42539e106528fee67763ae
   - name: registry.internal.white.fm/appstore-ui
-    newName: registry.internal.white.fm/appstore-ui
-    newTag: "0.1.0"
+    newName: ghcr.io/robertdwhite/appstore-ui
+    digest: sha256:d1986afe997f0ed39493466f492ffe48f3504df5631773d1c3f6d564b833402c


### PR DESCRIPTION
Cutover for appstore-reviews (public repo + public ghcr packages).

- Source -> RobertDWhite/appstore-reviews, multi-arch CI.
- appstore-app -> ghcr.io/robertdwhite/appstore-app@sha256:908ef0f…
- appstore-ui  -> ghcr.io/robertdwhite/appstore-ui@sha256:d1986afe…

Multi-arch (amd64+arm64), digest-pinned.