### PR TITLE
hub + backoffice-api: private ghcr images via pull secrets

### DIFF
--- a/backoffice/12-ghcr-pull.sops.yaml
+++ b/backoffice/12-ghcr-pull.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: ghcr-pull
+    namespace: backoffice
+type: kubernetes.io/dockerconfigjson
+stringData:
+    .dockerconfigjson: ENC[AES256_GCM,data:wrKw39Tzh9zVweSoP3+IObqvsZWDAmRX7zbf6v6fA1BPZTO/vX64soO+N/Ty7l7XQoZbvBYdCEW9UsYMUdyVO5d/PuSAYuMok8D3D92lCCw0lTkQ0ywl5x8CSMApJzPsSjTKKwEZ0HATl+C8f/brpSwk2efSeWEZ5C+O1VmeRn70sZ4cBrMB92zGxuOn8y20rKp82TmyW5hybH5rw2fmVxywsH47HB5wxZJaOQLXCnA73mgHa/WDyT019T8DRJsD,iv:aaEDDAO9AuJ1TKVdJf4mLhy2L3X7IBEoSnFVqvJFi5I=,tag:bzU9NmhOyXrY1th5pSjgTw==,type:str]
+sops:
+    age:
+        - recipient: age16krjysalsq26mfndnthd9r42thapj43a0zdndgrrz30utzuhwd0q7fxh9p
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFVVl4S0VYWThFeVZQYmxH
+            M3hIWGVDblZYalN5Y0h6S3MzQ3NXT3QxWmtBCmQ2QktrQ0xTNGdJa0pDVTdheUQy
+            akJ5OS9McVo3TkpjazFNS2MwVW4wa1kKLS0tIDVxcytJNjN6eW1RMlhmbkN4NlZC
+            aGVpbi9kNHRRYVgzd3YwbjhOTjhueUEKSk/qPD1VjQGKEjecw/4+LM4sMOD8M3fO
+            F12kBD50aDku0YMHaJigylAoP+9C5PWaO2ObPwQB4eyWl2hWLNuLAQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-02T20:25:12Z"
+    mac: ENC[AES256_GCM,data:SiIVqMeyOWW2biiK08EVIfje/c4D38abRIYymaBk506pRur17QP8KHPOZuBCMs2eA0+rc2Yv1MY8N4ExyB1uvL01/EKFCAtP9uc+wdgDR7ftuFwO5QJva2gh1qBL5S2ILKKa6EqbKipGOhcpKZCASwK+kHCfrp5g0fE2iD8+Z2g=,iv:WSqCOeIxiZO4cjS/ByXnOn/7LS6AVXrGDJwz8/NbtUE=,tag:/Zmoa9XWhrMCLsWBm4blng==,type:str]
+    encrypted_regex: ^(data|stringData|parameters)$
+    version: 3.10.2

--- a/backoffice/21-api-deployment.yaml
+++ b/backoffice/21-api-deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: backoffice-api
     spec:
+      imagePullSecrets:
+        - name: ghcr-pull
       serviceAccountName: backoffice-api
       nodeSelector:
         kubernetes.io/arch: amd64

--- a/backoffice/kustomization.yaml
+++ b/backoffice/kustomization.yaml
@@ -23,6 +23,7 @@ images:
     newTag: "16-alpine"
     digest: "sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229"
   - name: registry.internal.white.fm/backoffice-api
-    newTag: "0.2.3"
+    newName: ghcr.io/robertdwhite/backoffice-api
+    digest: sha256:5709a92d579006723068e5989242382ad20eb6b8c96744d4497b150068f3eb3b
   - name: registry.internal.white.fm/backoffice-web
     newTag: "0.2.1"

--- a/hub/10-deployment.yaml
+++ b/hub/10-deployment.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         app: hub-ui
     spec:
+      imagePullSecrets:
+        - name: ghcr-pull
       containers:
         - name: hub-ui
           image: registry.internal.white.fm/hub-ui

--- a/hub/11-ghcr-pull.sops.yaml
+++ b/hub/11-ghcr-pull.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: ghcr-pull
+    namespace: hub
+type: kubernetes.io/dockerconfigjson
+stringData:
+    .dockerconfigjson: ENC[AES256_GCM,data:+/QEMw358DqPlC983lvvwyTQT6y1w4A22ad53BVarpQEfC7mRp5QHx69kv9eRNMfga3WdPDq+TjQLMFEDL3rEg+ldFVIHghMLnSedRMrDlkzKKyo95yPUNVEBQEcA2SyWfwDyMXqd2keJIkuBGVrCegAyLGyRHnzyL/auKh6+YeLy21kI0H4guLSP/rEIslWu+6ZCX1M3Jf5Bzpo/sa82o71yFkc3gJ+uNTaQhB+5cYVy47PVzN9+WYWL2IrUk+o,iv:n2QsfPTVIO+K1UpsUwoTHXCTxLpt9Z6zlnjJfpMqY6c=,tag:HsuBH2wiNUkp0ljJRDZiPA==,type:str]
+sops:
+    age:
+        - recipient: age16krjysalsq26mfndnthd9r42thapj43a0zdndgrrz30utzuhwd0q7fxh9p
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvQ3E3R1ZZVGc4UWJkbGtN
+            M2VKTW1iRWJnMCt4a0QydWtPbUZJMENSUGlJCmpBL0dmTlpiNVdUQnZKTlJMY0U3
+            R04reHZsVEhjTjdWNUNZQUJ0bERZS0EKLS0tIExEdkZzbGdndThRR2d5N0RkWFJT
+            RU1WZStUQ2lJWGMxc3ZDQUVVbGROUUkKkYgpfHQtuqiJ8mZUnmehoqhu6ZjgLZq/
+            oAcsHO8fFOYv9r+fSruPdYu4iROhgwRRU2LbqgO1rPx939RXTNiXoQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-02T20:25:11Z"
+    mac: ENC[AES256_GCM,data:u6BTYMB/p+iC31eVRxTZLE11T2oGZh/bgUa9k+ukxirUUJyYFQxtVVWJxv8sqUgt7flyIRetI4YvE01ShWXTdRno9YWxSxY/B5G/4AeahPCLRB7tT4OiqzJN7cDOsj7NpH5sj/Y9DYpf+pOcNqjtZPAerlP/zIKawpd6/sxjz0c=,iv:Emj/zMaKxP0KeMGWi6rtZxt+/HW4fTynW4zUEvOdEtA=,tag:KjHCPG9uFsnkps89hvpFFA==,type:str]
+    encrypted_regex: ^(data|stringData|parameters)$
+    version: 3.10.2

--- a/hub/ksops.yaml
+++ b/hub/ksops.yaml
@@ -1,11 +1,10 @@
 apiVersion: viaduct.ai/v1
 kind: Ksops
 metadata:
-  name: backoffice-secret-generator
+  name: hub-secret-generator
   annotations:
     config.kubernetes.io/function: |
       exec:
         path: ksops
 files:
-  - 11-postgres-secret.sops.yaml
-  - 12-ghcr-pull.sops.yaml
+  - 11-ghcr-pull.sops.yaml

--- a/hub/kustomization.yaml
+++ b/hub/kustomization.yaml
@@ -9,6 +9,10 @@ resources:
   - 20-service.yaml
   - 53-httproute-internal.yaml
 
+generators:
+  - ksops.yaml
+
 images:
   - name: registry.internal.white.fm/hub-ui
-    newTag: "1.0.4"
+    newName: ghcr.io/robertdwhite/hub-ui
+    digest: sha256:3426602329a5e722e5eecb71ff08f97068fe24d9f0f66dcc4d3fb74b95691f14


### PR DESCRIPTION
Cutover for the two private apps from batch 3.

- **hub** (private): new KSOPS-managed `ghcr-pull` secret + imagePullSecrets;
  hub-ui -> ghcr.io/robertdwhite/hub-ui (multi-arch, digest-pinned).
- **backoffice** (private): `ghcr-pull` secret added to existing KSOPS +
  imagePullSecrets on the api deployment; backoffice-api ->
  ghcr.io/robertdwhite/backoffice-api (multi-arch, digest-pinned).
- **backoffice-web stays on the internal registry** (`:0.2.1`) — its Next.js
  build is broken (pre-existing dep drift: next/tailwind/ts majors). Will cut
  over once that's fixed.

Pull tokens were SOPS-encrypted (read:packages), never committed in plaintext
or echoed. Verified both images pull with the token (HTTP 200).