### PR TITLE
congress-trades: app/ui -> ghcr (digest-pinned) + drop dead CI job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,54 +10,6 @@ permissions:
   security-events: write
 
 jobs:
-  congress-trades:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: congress-trades
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
-
-      - name: Install backend dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r app/requirements.txt
-
-      - name: Backend compile check
-        run: python -m compileall app/app app/ingest ../congress-mcp/src
-
-      - name: Backend tests
-        working-directory: congress-trades/app
-        run: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests
-
-      - name: Parse Congress manifests
-        run: |
-          python - <<'PY'
-          from pathlib import Path
-          import yaml
-
-          for path in sorted(Path(".").glob("*.yaml")):
-              with path.open() as f:
-                  list(yaml.safe_load_all(f))
-              print(f"parsed {path}")
-          PY
-
-      - name: Set up Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-
-      - name: UI build
-        working-directory: congress-trades/ui
-        run: |
-          npm install --legacy-peer-deps
-          npm run build
-
   validate:
     runs-on: ubuntu-latest
     steps:

--- a/congress-trades/kustomization.yaml
+++ b/congress-trades/kustomization.yaml
@@ -39,8 +39,8 @@ generators:
 
 images:
   - name: registry.internal.white.fm/congress-app
-    newName: registry.internal.white.fm/congress-app
-    newTag: "0.4.2"
+    newName: ghcr.io/robertdwhite/congress-app
+    digest: sha256:7b14d46ebb8313f20cb8c47987ddf2f77691ad315badd2884389e785dd621d96
   - name: registry.internal.white.fm/congress-ui
-    newName: registry.internal.white.fm/congress-ui
-    newTag: "0.4.2"
+    newName: ghcr.io/robertdwhite/congress-ui
+    digest: sha256:7981841f7fab6f1ed34f8c53391fbff05988ab097ace8706714159ca070d456e


### PR DESCRIPTION
Cutover for congress-trades (public repo + public ghcr packages).

- Source -> RobertDWhite/congress-trades (multi-arch CI + pytest/compile).
- congress-app -> ghcr.io/robertdwhite/congress-app@sha256:7b14d46e…
- congress-ui  -> ghcr.io/robertdwhite/congress-ui@sha256:7981841f…
  (the image transformer rewrites the deployment + all ~17 cronjobs)
- Removes the **congress-trades job from `.github/workflows/validate.yml`** —
  it built the now-extracted UI and referenced the removed `congress-mcp/src`;
  that build+test now runs in the new repo. Fixes the perpetually-red check.