### PR TITLE
restructure: add AppProjects (platform/security/observability/apps)

### DIFF
--- a/argo-cd/applications/project-apps.yaml
+++ b/argo-cd/applications/project-apps.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: apps
+  namespace: argocd
+spec:
+  description: User-facing workloads
+  # Permissive during migration so moving apps into this project never breaks
+  # them. Tighten sourceRepos / clusterResourceWhitelist once apps have landed.
+  sourceRepos:
+    - "*"
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: "*"
+  clusterResourceWhitelist:
+    - group: "*"
+      kind: "*"
+  namespaceResourceWhitelist:
+    - group: "*"
+      kind: "*"

--- a/argo-cd/applications/project-observability.yaml
+++ b/argo-cd/applications/project-observability.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: observability
+  namespace: argocd
+spec:
+  description: Metrics, logs, dashboards, uptime
+  # Permissive during migration so moving apps into this project never breaks
+  # them. Tighten sourceRepos / clusterResourceWhitelist once apps have landed.
+  sourceRepos:
+    - "*"
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: "*"
+  clusterResourceWhitelist:
+    - group: "*"
+      kind: "*"
+  namespaceResourceWhitelist:
+    - group: "*"
+      kind: "*"

--- a/argo-cd/applications/project-platform.yaml
+++ b/argo-cd/applications/project-platform.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: platform
+  namespace: argocd
+spec:
+  description: Cluster infrastructure: controllers, networking, storage, policy
+  # Permissive during migration so moving apps into this project never breaks
+  # them. Tighten sourceRepos / clusterResourceWhitelist once apps have landed.
+  sourceRepos:
+    - "*"
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: "*"
+  clusterResourceWhitelist:
+    - group: "*"
+      kind: "*"
+  namespaceResourceWhitelist:
+    - group: "*"
+      kind: "*"

--- a/argo-cd/applications/project-security.yaml
+++ b/argo-cd/applications/project-security.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: security
+  namespace: argocd
+spec:
+  description: Security & identity tooling
+  # Permissive during migration so moving apps into this project never breaks
+  # them. Tighten sourceRepos / clusterResourceWhitelist once apps have landed.
+  sourceRepos:
+    - "*"
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: "*"
+  clusterResourceWhitelist:
+    - group: "*"
+      kind: "*"
+  namespaceResourceWhitelist:
+    - group: "*"
+      kind: "*"


### PR DESCRIPTION
Step 1 of the restructure (tier grouping). Adds 4 AppProjects, applied by
the app-of-apps from argo-cd/applications/.

- **Additive + permissive**: nothing references them yet, so creating them is a
  no-op for the cluster. They're intentionally wide-open (sourceRepos/destinations/
  resources = `*`) so that moving apps into them in step 3 can never break an app;
  they'll be tightened once apps have landed.
- Enables per-tier blast-radius isolation (replacing everything in project: default).

Next: step 3 moves app dirs into platform/security/observability/apps tiers,
one tier per PR, setting each app's project + path together.