### PR TITLE
fix: quote AppProject descriptions (invalid YAML broke app-of-apps render)

### DIFF
--- a/argo-cd/applications/project-apps.yaml
+++ b/argo-cd/applications/project-apps.yaml
@@ -4,7 +4,7 @@ metadata:
   name: apps
   namespace: argocd
 spec:
-  description: User-facing workloads
+  description: "User-facing workloads"
   # Permissive during migration so moving apps into this project never breaks
   # them. Tighten sourceRepos / clusterResourceWhitelist once apps have landed.
   sourceRepos:

--- a/argo-cd/applications/project-observability.yaml
+++ b/argo-cd/applications/project-observability.yaml
@@ -4,7 +4,7 @@ metadata:
   name: observability
   namespace: argocd
 spec:
-  description: Metrics, logs, dashboards, uptime
+  description: "Metrics, logs, dashboards, uptime"
   # Permissive during migration so moving apps into this project never breaks
   # them. Tighten sourceRepos / clusterResourceWhitelist once apps have landed.
   sourceRepos:

--- a/argo-cd/applications/project-platform.yaml
+++ b/argo-cd/applications/project-platform.yaml
@@ -4,7 +4,7 @@ metadata:
   name: platform
   namespace: argocd
 spec:
-  description: Cluster infrastructure: controllers, networking, storage, policy
+  description: "Cluster infrastructure: controllers, networking, storage, policy"
   # Permissive during migration so moving apps into this project never breaks
   # them. Tighten sourceRepos / clusterResourceWhitelist once apps have landed.
   sourceRepos:

--- a/argo-cd/applications/project-security.yaml
+++ b/argo-cd/applications/project-security.yaml
@@ -4,7 +4,7 @@ metadata:
   name: security
   namespace: argocd
 spec:
-  description: Security & identity tooling
+  description: "Security & identity tooling"
   # Permissive during migration so moving apps into this project never breaks
   # them. Tighten sourceRepos / clusterResourceWhitelist once apps have landed.
   sourceRepos:


### PR DESCRIPTION
Hotfix for #443. project-platform.yaml's description had an unquoted colon
('Cluster infrastructure: controllers...') = invalid YAML, which fails the
app-of-apps directory render. Quotes all 4 descriptions. Validated locally with
PyYAML. **Merge to unjam the app-of-apps.**