### PR TITLE
restructure: tighten AppProjects into real guardrails

### DIFF
--- a/argo-cd/applications/project-apps.yaml
+++ b/argo-cd/applications/project-apps.yaml
@@ -5,13 +5,135 @@ metadata:
   namespace: argocd
 spec:
   description: "User-facing workloads"
-  # Permissive during migration so moving apps into this project never breaks
-  # them. Tighten sourceRepos / clusterResourceWhitelist once apps have landed.
+  # sourceRepos scoped to the git/Helm repos this project's apps actually use.
+  # Defense-in-depth with the Kyverno image-registry allowlist.
   sourceRepos:
-    - "*"
+    - ghcr.io/openclaw-rocks/charts
+    - git@github.com:RobertDWhite/whitehouse-glacier.git
+    - git@github.com:RobertDWhite/whitehouse-rke2.git
+    - https://bjw-s-labs.github.io/helm-charts/
+    - https://github.com/RobertDWhite/whitehouse-rke2.git
+    - https://portainer.github.io/k8s/
+  # Destinations scoped to exactly the namespaces this project's apps deploy
+  # into (computed from their CRs + manifests). This fences these workloads
+  # out of infra namespaces (kube-system, cert-manager, longhorn-system, ...).
+  # A new namespace must be added here on purpose. Failure mode is a blocked
+  # sync (OutOfSync) -- never a prune.
   destinations:
     - server: https://kubernetes.default.svc
-      namespace: "*"
+      namespace: adsb
+    - server: https://kubernetes.default.svc
+      namespace: ai
+    - server: https://kubernetes.default.svc
+      namespace: ai-stack
+    - server: https://kubernetes.default.svc
+      namespace: appstore-reviews
+    - server: https://kubernetes.default.svc
+      namespace: astronomy
+    - server: https://kubernetes.default.svc
+      namespace: audiobookshelf
+    - server: https://kubernetes.default.svc
+      namespace: backoffice
+    - server: https://kubernetes.default.svc
+      namespace: calibre
+    - server: https://kubernetes.default.svc
+      namespace: codex-refresh
+    - server: https://kubernetes.default.svc
+      namespace: congress-mcp
+    - server: https://kubernetes.default.svc
+      namespace: congress-trades
+    - server: https://kubernetes.default.svc
+      namespace: convos
+    - server: https://kubernetes.default.svc
+      namespace: cyberchef
+    - server: https://kubernetes.default.svc
+      namespace: dispatcharr
+    - server: https://kubernetes.default.svc
+      namespace: envoy-gateway-system
+    - server: https://kubernetes.default.svc
+      namespace: fleet
+    - server: https://kubernetes.default.svc
+      namespace: freshrss
+    - server: https://kubernetes.default.svc
+      namespace: gibt-es-gott
+    - server: https://kubernetes.default.svc
+      namespace: glacier
+    - server: https://kubernetes.default.svc
+      namespace: glance
+    - server: https://kubernetes.default.svc
+      namespace: ground-station
+    - server: https://kubernetes.default.svc
+      namespace: hermes
+    - server: https://kubernetes.default.svc
+      namespace: homarr
+    - server: https://kubernetes.default.svc
+      namespace: homebridge
+    - server: https://kubernetes.default.svc
+      namespace: homepage
+    - server: https://kubernetes.default.svc
+      namespace: homeschool
+    - server: https://kubernetes.default.svc
+      namespace: hub
+    - server: https://kubernetes.default.svc
+      namespace: immich
+    - server: https://kubernetes.default.svc
+      namespace: intelowl
+    - server: https://kubernetes.default.svc
+      namespace: jetlog
+    - server: https://kubernetes.default.svc
+      namespace: jetlog-mcp
+    - server: https://kubernetes.default.svc
+      namespace: kavita
+    - server: https://kubernetes.default.svc
+      namespace: keeptrack
+    - server: https://kubernetes.default.svc
+      namespace: mastodon
+    - server: https://kubernetes.default.svc
+      namespace: matrix
+    - server: https://kubernetes.default.svc
+      namespace: media
+    - server: https://kubernetes.default.svc
+      namespace: media-mcp
+    - server: https://kubernetes.default.svc
+      namespace: misp
+    - server: https://kubernetes.default.svc
+      namespace: monica
+    - server: https://kubernetes.default.svc
+      namespace: monica-mcp
+    - server: https://kubernetes.default.svc
+      namespace: nitter
+    - server: https://kubernetes.default.svc
+      namespace: ntfy
+    - server: https://kubernetes.default.svc
+      namespace: ombi
+    - server: https://kubernetes.default.svc
+      namespace: openclaw
+    - server: https://kubernetes.default.svc
+      namespace: openclaw-operator-system
+    - server: https://kubernetes.default.svc
+      namespace: openhamclock
+    - server: https://kubernetes.default.svc
+      namespace: politics
+    - server: https://kubernetes.default.svc
+      namespace: portainer
+    - server: https://kubernetes.default.svc
+      namespace: postfix
+    - server: https://kubernetes.default.svc
+      namespace: raven
+    - server: https://kubernetes.default.svc
+      namespace: scrypted
+    - server: https://kubernetes.default.svc
+      namespace: sdr-research
+    - server: https://kubernetes.default.svc
+      namespace: tautulli
+    - server: https://kubernetes.default.svc
+      namespace: weather
+    - server: https://kubernetes.default.svc
+      namespace: worldmonitor
+    - server: https://kubernetes.default.svc
+      namespace: yeti
+  # Resource whitelists stay open: this tier includes Helm charts/operators whose
+  # full cluster-resource set (CRDs, webhooks, ClusterRoles) isn't visible in git.
   clusterResourceWhitelist:
     - group: "*"
       kind: "*"

--- a/argo-cd/applications/project-observability.yaml
+++ b/argo-cd/applications/project-observability.yaml
@@ -5,13 +5,28 @@ metadata:
   namespace: argocd
 spec:
   description: "Metrics, logs, dashboards, uptime"
-  # Permissive during migration so moving apps into this project never breaks
-  # them. Tighten sourceRepos / clusterResourceWhitelist once apps have landed.
+  # sourceRepos scoped to the git/Helm repos this project's apps actually use.
+  # Defense-in-depth with the Kyverno image-registry allowlist.
   sourceRepos:
-    - "*"
+    - git@github.com:RobertDWhite/whitehouse-rke2.git
+    - https://github.com/RobertDWhite/whitehouse-rke2.git
+    - https://prometheus-community.github.io/helm-charts
+  # Destinations scoped to exactly the namespaces this project's apps deploy
+  # into (computed from their CRs + manifests). This fences these workloads
+  # out of infra namespaces (kube-system, cert-manager, longhorn-system, ...).
+  # A new namespace must be added here on purpose. Failure mode is a blocked
+  # sync (OutOfSync) -- never a prune.
   destinations:
     - server: https://kubernetes.default.svc
-      namespace: "*"
+      namespace: kube-system
+    - server: https://kubernetes.default.svc
+      namespace: myspeed
+    - server: https://kubernetes.default.svc
+      namespace: observability
+    - server: https://kubernetes.default.svc
+      namespace: uptime-kuma
+  # Resource whitelists stay open: this tier includes Helm charts/operators whose
+  # full cluster-resource set (CRDs, webhooks, ClusterRoles) isn't visible in git.
   clusterResourceWhitelist:
     - group: "*"
       kind: "*"

--- a/argo-cd/applications/project-platform.yaml
+++ b/argo-cd/applications/project-platform.yaml
@@ -5,13 +5,26 @@ metadata:
   namespace: argocd
 spec:
   description: "Cluster infrastructure: controllers, networking, storage, policy"
-  # Permissive during migration so moving apps into this project never breaks
-  # them. Tighten sourceRepos / clusterResourceWhitelist once apps have landed.
+  # sourceRepos scoped to the git/Helm repos this project's apps actually use.
+  # Defense-in-depth with the Kyverno image-registry allowlist.
   sourceRepos:
-    - "*"
+    - git@github.com:RobertDWhite/whitehouse-rke2.git
+    - https://charts.external-secrets.io
+    - https://charts.jetstack.io
+    - https://charts.longhorn.io
+    - https://github.com/RobertDWhite/whitehouse-rke2.git
+    - https://github.com/rancher/local-path-provisioner
+    - https://kyverno.github.io/kyverno/
+    - https://vmware-tanzu.github.io/helm-charts
+  # Destinations stay open: platform hosts cross-cutting deployers
+  # (network-policies, external-secrets, cert-manager, external-dns) that
+  # legitimately write resources into ~every namespace. Scoping here would
+  # be an all-namespaces list that guards nothing.
   destinations:
     - server: https://kubernetes.default.svc
       namespace: "*"
+  # Resource whitelists stay open: this tier includes Helm charts/operators whose
+  # full cluster-resource set (CRDs, webhooks, ClusterRoles) isn't visible in git.
   clusterResourceWhitelist:
     - group: "*"
       kind: "*"

--- a/argo-cd/applications/project-security.yaml
+++ b/argo-cd/applications/project-security.yaml
@@ -5,13 +5,32 @@ metadata:
   namespace: argocd
 spec:
   description: "Security & identity tooling"
-  # Permissive during migration so moving apps into this project never breaks
-  # them. Tighten sourceRepos / clusterResourceWhitelist once apps have landed.
+  # sourceRepos scoped to the git/Helm repos this project's apps actually use.
+  # Defense-in-depth with the Kyverno image-registry allowlist.
   sourceRepos:
-    - "*"
+    - git@github.com:RobertDWhite/whitehouse-rke2.git
+    - https://aquasecurity.github.io/helm-charts/
+    - https://crowdsecurity.github.io/helm-charts
+    - https://falcosecurity.github.io/charts
+    - https://github.com/RobertDWhite/whitehouse-rke2.git
+  # Destinations scoped to exactly the namespaces this project's apps deploy
+  # into (computed from their CRs + manifests). This fences these workloads
+  # out of infra namespaces (kube-system, cert-manager, longhorn-system, ...).
+  # A new namespace must be added here on purpose. Failure mode is a blocked
+  # sync (OutOfSync) -- never a prune.
   destinations:
     - server: https://kubernetes.default.svc
-      namespace: "*"
+      namespace: authentik
+    - server: https://kubernetes.default.svc
+      namespace: crowdsec
+    - server: https://kubernetes.default.svc
+      namespace: falco
+    - server: https://kubernetes.default.svc
+      namespace: kube-bench
+    - server: https://kubernetes.default.svc
+      namespace: trivy-system
+  # Resource whitelists stay open: this tier includes Helm charts/operators whose
+  # full cluster-resource set (CRDs, webhooks, ClusterRoles) isn't visible in git.
   clusterResourceWhitelist:
     - group: "*"
       kind: "*"


### PR DESCRIPTION
Closes the "AppProjects are decorative" gap. They were left permissive on
purpose during the tier migration (the CRs literally said *"Tighten ... once
apps have landed"*) — apps have landed.

## What changes
| project | destinations | sourceRepos | resource whitelists |
|---|---|---|---|
| **platform** | stay `*` (see below) | scoped to 8 repos | stay `*` |
| **security** | scoped to **5** namespaces | scoped to 5 repos | stay `*` |
| **observability** | scoped to **4** namespaces | scoped to 3 repos | stay `*` |
| **apps** | scoped to **56** namespaces | scoped to 6 repos | stay `*` |

The `apps` namespace set excludes **every** infra/security/observability
namespace (`kube-system`, `cert-manager`, `longhorn-system`, `kyverno`,
`argocd`, `external-secrets`, `velero`, `metallb-system`, `falco`,
`trivy-system`, ...). So a misconfigured/compromised user-facing Application can
no longer land workloads in infrastructure namespaces.

## Deliberate non-changes (with reasons)
- **`platform` destinations stay `*`** — it hosts cross-cutting deployers
  (`network-policies` writes NetworkPolicies into ~44 app namespaces,
  `external-secrets`/`cert-manager`/`external-dns` write across the cluster).
  Scoping would be an all-namespaces list that guards nothing, and risks
  breaking those controllers. It's the trusted infra tier.
- **Resource whitelists stay `*`** — `apps` (and the infra tiers) include Helm
  charts/operators (`openclaw-operator`, `app-template`, `portainer`, `falco`,
  `trivy-operator`, ...) whose full cluster-resource set (CRDs, webhooks,
  ClusterRoles) isn't visible in git. Denying cluster resources risks breakage
  for little isolation gain; destinations scoping is the high-value win.

## Safety
- Every Application's full target-namespace set **and** repo set was verified to
  be a subset of its project's allowance — **0 apps blocked**.
- Reminder: AppProjects are a *deploy-time* control. This does **not** touch
  runtime app-to-app traffic (that's the 184 NetworkPolicies in
  `platform/policy/network-policies/`).
- Failure mode if a Helm chart renders into an unforeseen namespace: that one
  app shows `OutOfSync` with an explicit "namespace not permitted" message —
  **no prune, no traffic impact** — fixed by adding the namespace.