### PR TITLE
hub: deploy favicon build (digest bump)

### DIFF
--- a/apps/home/hub/kustomization.yaml
+++ b/apps/home/hub/kustomization.yaml
@@ -15,4 +15,4 @@ generators:
 images:
   - name: registry.internal.white.fm/hub-ui
     newName: ghcr.io/robertdwhite/hub-ui
-    digest: sha256:3426602329a5e722e5eecb71ff08f97068fe24d9f0f66dcc4d3fb74b95691f14
+    digest: sha256:d220b4bb18578cc5171014f7706075acb5f87244319ed5427cfbfcff61e98e33


### PR DESCRIPTION
Bumps the pinned `hub-ui` image in `apps/home/hub/kustomization.yaml` to the build from RobertDWhite/hub#1 (adds the favicon).

- `sha256:3426602…f48ee` → `sha256:d220b4bb…e98e33`
- Verified: new image is the same app bundle (`index-CVJrRCfN.js`) as the currently-running pod, plus `/favicon.svg` and the `<link rel="icon">`.

ArgoCD (`hub` app, auto-sync) will roll the new pod once merged.