### PR TITLE
argocd: enable git-fetch retries on repo-server (fix intermittent SSH ComparisonError)

### DIFF
--- a/argocd/values/argocd-values.yaml
+++ b/argocd/values/argocd-values.yaml
@@ -51,6 +51,19 @@ repoServer:
     value: /etc/sops/age/key.txt
   - name: ARGOCD_KUBECTL_IMAGE
     value: docker.io/bitnami/kubectl:1.30.5
+  # Retry git fetches. The SSH transport intermittently throws
+  # 'SSH agent requested but SSH_AUTH_SOCK not-specified' (argoproj/argo-cd#8084,
+  # #884, #6000) -- fetches succeed most of the time and randomly fail. The
+  # default is a single attempt, so one flaky fetch surfaces as a hard
+  # ComparisonError (apps stuck "Unknown"). Retrying with backoff masks it.
+  - name: ARGOCD_GIT_ATTEMPTS_COUNT
+    value: "5"
+  - name: ARGOCD_GIT_RETRY_DURATION
+    value: "1s"
+  - name: ARGOCD_GIT_RETRY_MAX_DURATION
+    value: "10s"
+  - name: ARGOCD_GIT_RETRY_FACTOR
+    value: "2"
   volumes:
   - name: custom-tools
     emptyDir: {}


### PR DESCRIPTION
## Problem
~25 apps sit `Unknown` on a `ComparisonError`:
`error creating SSH agent: "SSH agent requested but SSH_AUTH_SOCK not-specified"`.
The repo-server can't fetch `git@…rke2.git` for those, so they never see new
commits ("ArgoCD hasn't polled git"). Workloads are fine — `opState` shows
`successfully synced`; only the live comparison fails.

It's a [known intermittent ArgoCD bug](https://github.com/argoproj/argo-cd/issues/8084)
(also [#884](https://github.com/argoproj/argo-cd/issues/884),
[#6000](https://github.com/argoproj/argo-cd/issues/6000)): SSH fetches succeed
most of the time and randomly throw. A `rollout restart` of the repo-server did
**not** fix it — the error recurs on fresh pods and the affected set shifts each
comparison cycle, i.e. it's probabilistic per fetch, not stale state.

## Fix
The repo-server had **no git-retry configured** (ArgoCD default = 1 attempt), so
a single flaky fetch becomes a hard error. Add retry + backoff env vars so the
fetch is retried instead:

```yaml
- name: ARGOCD_GIT_ATTEMPTS_COUNT    # 5 attempts
- name: ARGOCD_GIT_RETRY_DURATION    # 1s
- name: ARGOCD_GIT_RETRY_MAX_DURATION # 10s cap
- name: ARGOCD_GIT_RETRY_FACTOR      # 2x exponential
```

Additive, reversible, no credential change. On merge, ArgoCD self-syncs the
`argocd` app → repo-server rolls with the new env.

## Why now
Reliable git fetches are a **prerequisite for the ApplicationSet step-2 cutover**
(#458): the git-files generator polls this same SSH repo, so intermittent fetch
failures would make the orphan-and-adopt and the live `appset generate` parity
gate unreliable.

## Verify after sync
`kubectl get applications.argoproj.io -n argocd` → the `Unknown` count should
drop toward zero. (Deeper root-cause — why go-git falls back to SSH-agent — would
need repo-server log/cred inspection; this masks the symptom reliably. The clean
long-term option is moving the repo connection to HTTPS, which the AppProject
guardrails already permit.)