### PR TITLE
fix: resolve post-outage crashloops (headscale v0.29, coredns mem, cyberchef, keeptrack)

### DIFF
--- a/apps/misc/cyberchef/10-deployment.yaml
+++ b/apps/misc/cyberchef/10-deployment.yaml
@@ -19,6 +19,15 @@ spec:
           image: ghcr.io/gchq/cyberchef
           ports:
             - containerPort: 80
+          # Give the static nginx time to come up before liveness/readiness
+          # engage — the aggressive liveness probe was reaping it mid-start,
+          # leaving the pod in a permanent CrashLoopBackOff.
+          startupProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 5
+            failureThreshold: 30
           readinessProbe:
             httpGet:
               path: /

--- a/apps/radio/keeptrack/10-deployment.yaml
+++ b/apps/radio/keeptrack/10-deployment.yaml
@@ -13,6 +13,10 @@ spec:
       labels:
         app: keeptrack
     spec:
+      # The keeptrack image is amd64-only; pin it off the arm64 node (node-10),
+      # where it was hitting `exec format error` and CrashLoopBackOff.
+      nodeSelector:
+        kubernetes.io/arch: amd64
       containers:
         - name: keeptrack
           image: registry.internal.white.fm/keeptrack

--- a/platform/networking/dns/ebl-amazonaws.yaml
+++ b/platform/networking/dns/ebl-amazonaws.yaml
@@ -86,6 +86,16 @@ spec:
         mountPath: /etc/coredns/extra
         readOnly: true
 
+    # The 128Mi chart default OOMKills coredns under the DNS query-storm during
+    # mass pod recovery (e.g. after a power outage), which flaps cluster DNS and
+    # deadlocks Longhorn/technitium recovery. 512Mi survives the storm.
+    resources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
     # Default zone: prefer the dnscrypt-proxy → VPN chain for privacy on
     # external lookups, fall back to public DNS so the cluster keeps
     # functioning when the VPN is degraded. health_check marks unhealthy

--- a/platform/networking/headscale/01-configmap-headscale.yaml
+++ b/platform/networking/headscale/01-configmap-headscale.yaml
@@ -30,7 +30,14 @@ data:
       update_frequency: 24h
 
     disable_check_updates: true
-    ephemeral_node_inactivity_timeout: 30m
+
+    # v0.29: node-key expiry and ephemeral-node inactivity moved under a unified
+    # `node:` block. `oidc.expiry` was removed (use node.expiry) and
+    # `ephemeral_node_inactivity_timeout` relocated to node.ephemeral.inactivity_timeout.
+    node:
+      expiry: 720h  # node key lifetime before forced re-auth (was oidc.expiry.node_expiry); 0 = never
+      ephemeral:
+        inactivity_timeout: 30m
 
     database:
       type: sqlite
@@ -98,6 +105,3 @@ data:
       # to the Headscale application, then set the matching groups here.
       # allowed_groups:
       #   - headscale-users
-      expiry:
-        # How long an OIDC-issued node key lasts before forcing re-auth.
-        node_expiry: 720h  # 30 days


### PR DESCRIPTION
Fixes 4 crashlooping workloads after the power-outage recovery. Merging lets ArgoCD sync and resolve them (apps are Synced/Degraded with selfHeal, so the fix must land on main).

## Changes
- **headscale**: migrate to v0.29 config schema — `oidc.expiry` (removed → FATAL) → `node.expiry`, and `ephemeral_node_inactivity_timeout` → `node.ephemeral.inactivity_timeout`. Also heals `tailscale-router` (was failing to fetch the control key while headscale was down).
- **rke2-coredns**: raise memory limit 128Mi → 512Mi. The 128Mi default OOMKills coredns under the DNS query-storm during mass pod recovery (e.g. a power outage), which flaps cluster DNS and deadlocks Longhorn/technitium recovery.
- **cyberchef**: add a `startupProbe` so the aggressive liveness probe stops reaping nginx mid-start.
- **keeptrack**: pin to amd64 nodes (`kubernetes.io/arch: amd64`) — the image is amd64-only and hit `exec format error` / CrashLoopBackOff on arm64 node-10.

## Note
Commit is unsigned: 1Password's SSH signing agent can't sign from a headless session. Re-sign/squash on merge if required by branch policy.

## Not covered (need host actions)
- immich: external Postgres `10.100.1.20:5435` (Synology) is down — restart that container.
- nvidia-device-plugin on node-50: reload the NVIDIA driver (`sudo modprobe nvidia`).