### PR TITLE
fix(cyberchef): serve on 8080 not 80 (fixes crashloop)

### DIFF
--- a/apps/misc/cyberchef/10-deployment.yaml
+++ b/apps/misc/cyberchef/10-deployment.yaml
@@ -18,26 +18,26 @@ spec:
         - name: cyberchef
           image: ghcr.io/gchq/cyberchef
           ports:
-            - containerPort: 80
-          # Give the static nginx time to come up before liveness/readiness
-          # engage — the aggressive liveness probe was reaping it mid-start,
-          # leaving the pod in a permanent CrashLoopBackOff.
+            - containerPort: 8080
+          # cyberchef 11.x serves on 8080 (not 80) — targeting :80 caused
+          # connection-refused crashloops. startupProbe also gives nginx time
+          # to come up before liveness/readiness engage.
           startupProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             periodSeconds: 5
             failureThreshold: 30
           readinessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             initialDelaySeconds: 10
             periodSeconds: 30
             failureThreshold: 3

--- a/apps/misc/cyberchef/20-service.yaml
+++ b/apps/misc/cyberchef/20-service.yaml
@@ -8,5 +8,5 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080  # cyberchef 11.x nginx serves on 8080
   type: ClusterIP


### PR DESCRIPTION
cyberchef 11.x nginx listens on 8080; the deployment/probes/service still targeted :80, causing a connection-refused CrashLoopBackOff. Points containerPort + all probes + service targetPort at 8080. Unsigned commit (1Password headless).