### PR TITLE
add pages static-site host + MCP upload tool

### DIFF
--- a/apps/ai/pages/00-namespace.yaml
+++ b/apps/ai/pages/00-namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pages
+  labels:
+    app.kubernetes.io/name: pages
+    app.kubernetes.io/part-of: personal-tools

--- a/apps/ai/pages/10-pvc.yaml
+++ b/apps/ai/pages/10-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pages-data
+  namespace: pages
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: longhorn

--- a/apps/ai/pages/11-secret.sops.yaml
+++ b/apps/ai/pages/11-secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: pages-env
+    namespace: pages
+type: Opaque
+stringData:
+    MCP_TOKEN: ENC[AES256_GCM,data:Z550jCQE2cS146uHTPDxZcsnfXPZukgfFPBFL56TtDE+oXoKf0j+iA2L2iMocRbrMXlfZ9fbKsK1Nu70SRiLjg==,iv:EtdwUhn9MDYK3DJPkGqFCBNIAEY0O8ilR0NZL0wITEs=,tag:W31ZWG67sixvB2fg8JZqRA==,type:str]
+sops:
+    age:
+        - recipient: age16krjysalsq26mfndnthd9r42thapj43a0zdndgrrz30utzuhwd0q7fxh9p
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEWVRiMVVZTWFnUHQ0LzYr
+            RVBTRzhqRkNWVVFuT1BGSmtVd3poTnJoL0RzCmozcXNiT3orcGVvZnZNek80SlVz
+            ZzUzTG9CN1BjY3k3SVFVNlJBdWE5elkKLS0tIG5MRXNyRE5RUG05RFZ4bDExQVpF
+            b0hWUlBuMjBueFdENFJBbGFtcjFITW8KfEKEA4DW/SzCBV8/qXj9kBSEbYoC/I88
+            zSpcBbJoTkWTxg2j8eF/VuoSG/8XRZv0VHpBSWvBJPPrMXmwW6VtxA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-22T04:41:02Z"
+    mac: ENC[AES256_GCM,data:+SOIoFxjzIQ7QKrbkZwefGvFrCcridhGb8/g7zULRkN9xZlMgD25XsBVPiSPWY7dICDfSnrJEm65G2+l6rnL9fOVluDrhw6sNuj3pV6sZyk/lzF6gxXFJR0qY2xmn8qFPWXBw/6JKnOwiTb0u/6bTJKKpYpqUpvONAQGQSol4j8=,iv:uPWsR6RzlskJd0cMzRBM13KVkjThX4AcPlirqUzeMQw=,tag:2bA1v9a61xqc7tBvpsie0g==,type:str]
+    encrypted_regex: ^(data|stringData|parameters)$
+    version: 3.10.2

--- a/apps/ai/pages/20-deployment.yaml
+++ b/apps/ai/pages/20-deployment.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pages
+  namespace: pages
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: pages
+  template:
+    metadata:
+      labels:
+        app: pages
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: pages
+          image: registry.internal.white.fm/pages-mcp
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          env:
+            - name: PORT
+              value: "8080"
+            - name: SITES_DIR
+              value: "/data/sites"
+            - name: SERVE_HOST
+              value: "pages.internal.white.fm"
+            - name: MCP_HOST
+              value: "pages-mcp.internal.white.fm"
+            - name: PUBLIC_BASE_URL
+              value: "https://pages.internal.white.fm"
+            - name: TMPDIR
+              value: "/tmp"
+            - name: MCP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: pages-env
+                  key: MCP_TOKEN
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 384Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: data
+              mountPath: /data/sites
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: pages-data
+        - name: tmp
+          emptyDir: {}

--- a/apps/ai/pages/30-service.yaml
+++ b/apps/ai/pages/30-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pages
+  namespace: pages
+spec:
+  selector:
+    app: pages
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP

--- a/apps/ai/pages/53-httproute-serve.yaml
+++ b/apps/ai/pages/53-httproute-serve.yaml
@@ -1,0 +1,18 @@
+# Open on the internal (tailnet-only) network: anyone who can resolve
+# *.internal.white.fm can view hosted sites. Uses the shared wildcard listener.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: pages-serve-internal
+  namespace: pages
+spec:
+  parentRefs:
+    - name: main
+      namespace: envoy-gateway-system
+      sectionName: https-internal-white-fm
+  hostnames:
+    - pages.internal.white.fm
+  rules:
+    - backendRefs:
+        - name: pages
+          port: 8080

--- a/apps/ai/pages/54-httproute-mcp.yaml
+++ b/apps/ai/pages/54-httproute-mcp.yaml
@@ -1,0 +1,18 @@
+# MCP control plane, bearer-token gated (MCP_TOKEN). The server only serves /mcp
+# on this host and 404s everything else here. Uses the shared wildcard listener.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: pages-mcp-internal
+  namespace: pages
+spec:
+  parentRefs:
+    - name: main
+      namespace: envoy-gateway-system
+      sectionName: https-internal-white-fm
+  hostnames:
+    - pages-mcp.internal.white.fm
+  rules:
+    - backendRefs:
+        - name: pages
+          port: 8080

--- a/apps/ai/pages/60-networkpolicy.yaml
+++ b/apps/ai/pages/60-networkpolicy.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: pages
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-envoy-gateway
+  namespace: pages
+spec:
+  podSelector:
+    matchLabels:
+      app: pages
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: envoy-gateway-system
+      ports:
+        - port: 8080
+          protocol: TCP

--- a/apps/ai/pages/61-pdb.yaml
+++ b/apps/ai/pages/61-pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: pages
+  namespace: pages
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: pages

--- a/apps/ai/pages/README.md
+++ b/apps/ai/pages/README.md
@@ -1,0 +1,38 @@
+# pages
+
+Self-hosted static-site host with an MCP upload tool. Source:
+[`github.com/RobertDWhite/pages-mcp`](https://github.com/RobertDWhite/pages-mcp)
+(also mirrored at `~/Documents/GitHubCurrent/pages-mcp`).
+
+- **Serve:** `https://pages.internal.white.fm/<site>/` — open on the internal
+  (tailnet-only) network, no Authentik gate. A directory index lists all sites.
+- **Upload (MCP):** `https://pages-mcp.internal.white.fm/mcp` —
+  `Authorization: Bearer <MCP_TOKEN>` (`11-secret.sops.yaml`).
+- **Storage:** Longhorn PVC `pages-data` (5Gi) at `/data/sites`, one dir per site.
+
+One Deployment serves both planes on `:8080`, split by Host header. The shared
+`*.internal.white.fm` wildcard listener + cert cover both hostnames — no dedicated
+gateway listener, cert, or DNS record needed.
+
+## MCP tools
+
+`deploy_site(name, files, replace=True)`, `list_sites()`, `get_site(name)`,
+`delete_site(name)`. See the source README for the `files` shape.
+
+## Build / deploy
+
+CI builds `ghcr.io/robertdwhite/pages-mcp` (amd64+arm64) on push to `main`/`v*`.
+Pin the digest in `kustomization.yaml`, commit, push — ArgoCD syncs.
+
+```sh
+crane digest ghcr.io/robertdwhite/pages-mcp:latest   # -> paste into kustomization.yaml
+```
+
+## Register with Claude Code
+
+```sh
+sops -d apps/ai/pages/11-secret.sops.yaml | grep MCP_TOKEN
+claude mcp add --transport http pages \
+  https://pages-mcp.internal.white.fm/mcp \
+  --header "Authorization: Bearer <MCP_TOKEN>"
+```

--- a/apps/ai/pages/ksops.yaml
+++ b/apps/ai/pages/ksops.yaml
@@ -1,0 +1,10 @@
+apiVersion: viaduct.ai/v1
+kind: Ksops
+metadata:
+  name: pages-secret-generator
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+files:
+  - 11-secret.sops.yaml

--- a/apps/ai/pages/kustomization.yaml
+++ b/apps/ai/pages/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - 00-namespace.yaml
+  - 10-pvc.yaml
+  - 20-deployment.yaml
+  - 30-service.yaml
+  - 53-httproute-serve.yaml
+  - 54-httproute-mcp.yaml
+  - 60-networkpolicy.yaml
+  - 61-pdb.yaml
+
+generators:
+  - ksops.yaml
+
+images:
+  # Built by github.com/RobertDWhite/pages-mcp CI -> ghcr.io. Pin the digest after
+  # the first build (crane digest ghcr.io/robertdwhite/pages-mcp:latest).
+  - name: registry.internal.white.fm/pages-mcp
+    newName: ghcr.io/robertdwhite/pages-mcp
+    digest: sha256:c31da78eb04496e64db7e9c13dcf871443e3ff3f4404d3eda74951b000a4e28e

--- a/argo-cd/applications/pages-app.yaml
+++ b/argo-cd/applications/pages-app.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: pages
+  namespace: argocd
+spec:
+  project: apps
+  source:
+    repoURL: git@github.com:RobertDWhite/whitehouse-rke2.git
+    targetRevision: main
+    path: apps/ai/pages
+    kustomize: {}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: pages
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/platform/storage/velero/schedules/daily.yaml
+++ b/platform/storage/velero/schedules/daily.yaml
@@ -41,6 +41,7 @@ spec:
       - homebridge
       - listmonk
       - odysseus
+      - pages
     snapshotVolumes: true
     snapshotMoveData: true
     ttl: 168h # 7 days


### PR DESCRIPTION
Adds `apps/ai/pages`: a static-site host that serves uploaded artifacts at `pages.internal.white.fm/<site>/` and exposes an MCP upload tool (`deploy_site`, `list_sites`, `get_site`, `delete_site`) at `pages-mcp.internal.white.fm/mcp`.

- One FastMCP/Starlette container (image `ghcr.io/robertdwhite/pages-mcp`, source: RobertDWhite/pages-mcp), Longhorn-backed PVC, bearer-gated control plane, open serving plane.
- Reuses the existing `*.internal.white.fm` wildcard listener/cert — no DNS or gateway changes.
- Adds the ArgoCD Application and the `pages` namespace to the Velero daily backup.