### PR TITLE
shelfmark: VPN egress + remove public route

### DIFF
--- a/apps/media/media/16-netpol-calibre-shelfmark-to-vpn.yaml
+++ b/apps/media/media/16-netpol-calibre-shelfmark-to-vpn.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-calibre-shelfmark-to-vpn
+  namespace: media
+spec:
+  podSelector:
+    matchLabels:
+      app: vpn-proxy
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: calibre
+          podSelector:
+            matchLabels:
+              app: shelfmark
+      ports:
+        - port: 1080
+          protocol: TCP
+        - port: 8888
+          protocol: TCP

--- a/apps/media/media/kustomization.yaml
+++ b/apps/media/media/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - 13-netpol-glacier.yaml
   - 14-netpol-calibre-lazylibrarian.yaml
   - 15-netpol-searxng-to-vpn.yaml
+  - 16-netpol-calibre-shelfmark-to-vpn.yaml
   - 30-exportarr.yaml
 
 generators:

--- a/apps/media/shelfmark/72-deployment-shelfmark.yaml
+++ b/apps/media/shelfmark/72-deployment-shelfmark.yaml
@@ -50,6 +50,12 @@ spec:
               value: "https://books.white.fm"
             - name: INGEST_DIR
               value: "/books"
+            - name: HTTP_PROXY
+              value: "http://vpn-proxy.media.svc.cluster.local:8888"
+            - name: HTTPS_PROXY
+              value: "http://vpn-proxy.media.svc.cluster.local:8888"
+            - name: NO_PROXY
+              value: "localhost,127.0.0.1,.cluster.local,.svc,.local,.white.fm"
           volumeMounts:
             - name: config
               mountPath: /config

--- a/platform/networking/envoy-phase3-routes/30-routes-batch2.yaml
+++ b/platform/networking/envoy-phase3-routes/30-routes-batch2.yaml
@@ -140,23 +140,6 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: shelfmark-public
-  namespace: calibre
-spec:
-  parentRefs:
-    - name: main
-      namespace: envoy-gateway-system
-      sectionName: https-white-fm
-  hostnames:
-    - shelfmark.white.fm
-  rules:
-    - backendRefs:
-        - name: shelfmark
-          port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
   name: ollama-public
   namespace: ai-stack
 spec:


### PR DESCRIPTION
Puts shelfmark behind the VPN and takes it off the public internet.

## Changes
1. **Egress via VPN proxy** — `apps/media/shelfmark/72-deployment-shelfmark.yaml`: adds `HTTP_PROXY`/`HTTPS_PROXY` -> `vpn-proxy.media.svc.cluster.local:8888` with `NO_PROXY=localhost,127.0.0.1,.cluster.local,.svc,.local,.white.fm`. Same egress path as lazylibrarian, so book-source downloads exit through the VPN while the in-cluster CWA call (`calibre-web-automated.calibre.svc`) and `*.white.fm` stay direct.
2. **NetworkPolicy** — new `apps/media/media/16-netpol-calibre-shelfmark-to-vpn.yaml` (+ kustomization entry): allows the shelfmark pod in `calibre` to reach the default-deny `vpn-proxy` in `media` on 1080/8888. Without this the proxy traffic is silently dropped.
3. **Remove public exposure** — `platform/networking/envoy-phase3-routes/30-routes-batch2.yaml`: drops the `shelfmark-public` HTTPRoute (`shelfmark.white.fm`). Shelfmark remains reachable internally at `shelfmark.internal.white.fm`.

## Notes
- `shelfmark.white.fm` will return 404 at the gateway after this merges; the wildcard DNS record can be left as-is or cleaned up separately.
- Assumes the shelfmark Flask app honors standard `*_PROXY` env vars (lazylibrarian does); worth a quick check that a download still completes after rollout.
- The `:latest` image trips the audit-only `require-image-digest` policy (warning, non-blocking) — unchanged from current state.