### PR TITLE
sdr: adaptive squelch, api 0.2.2 event-loop fixes, working ollama model

### DIFF
--- a/apps/radio/sdr-research/04-unified-sdr-configmap.yaml
+++ b/apps/radio/sdr-research/04-unified-sdr-configmap.yaml
@@ -42,6 +42,21 @@ data:
     MIN_REC_SEC    = float(os.getenv("MIN_REC_SEC", "0.5"))
     MAX_REC_SEC    = float(os.getenv("MAX_REC_SEC", "120"))
     RF_SQUELCH_DB  = float(os.getenv("RF_SQUELCH_DB", "-50"))
+    # Adaptive RF squelch: track each channel's noise floor and hold the squelch
+    # threshold a fixed margin above it. Static thresholds have failed in both
+    # directions here (below the floor → records noise 24/7; above real traffic →
+    # records nothing), because the floor moves with gain, hardware, and band
+    # conditions. RF_SQUELCH_DB is the initial threshold until the first
+    # measurement. Set AUTO_SQUELCH=0 to keep a fixed threshold.
+    AUTO_SQUELCH            = os.getenv("AUTO_SQUELCH", "1") not in ("0", "false", "no")
+    AUTO_SQUELCH_MARGIN_DB  = float(os.getenv("AUTO_SQUELCH_MARGIN_DB", "6"))
+    AUTO_SQUELCH_INTERVAL   = float(os.getenv("AUTO_SQUELCH_INTERVAL_SEC", "2"))
+    # Floor estimate follows drops immediately, rises slowly (dB per interval) so a
+    # transmission does not drag the floor up; it never rises while recording.
+    AUTO_SQUELCH_RISE_DB    = float(os.getenv("AUTO_SQUELCH_RISE_DB", "0.1"))
+    AUTO_SQUELCH_MIN_DB     = float(os.getenv("AUTO_SQUELCH_MIN_DB", "-70"))
+    AUTO_SQUELCH_MAX_DB     = float(os.getenv("AUTO_SQUELCH_MAX_DB", "-25"))
+    AUTO_SQUELCH_LOG_SEC    = float(os.getenv("AUTO_SQUELCH_LOG_SEC", "60"))
 
     FFT_SIZE       = int(os.getenv("FFT_SIZE", "4096"))
     FFT_INTERVAL   = float(os.getenv("FFT_INTERVAL", "1.0"))
@@ -305,9 +320,10 @@ data:
             self.connect(self.src, self.xlate_fixed, self.rf_squelch_fixed,
                          self.nbfm_fixed, self.rec_fixed)
 
-            # --- RF power probe on fixed channel (for threshold tuning) ---
-            self.rf_probe_fixed = blocks.probe_signal_c()
-            self.connect(self.xlate_fixed, self.rf_probe_fixed)
+            # --- RF power probe on fixed channel (feeds AutoSquelch) ---
+            self.probe_fixed = analog.probe_avg_mag_sqrd_c(0, 0.001)
+            self.connect(self.xlate_fixed, self.probe_fixed)
+            self.fixed_sq_state = {}
 
             # --- Dynamic FM slots (pre-wired with inhibited recorders) ---
             self.dyn_fm = []
@@ -318,10 +334,13 @@ data:
                     RF_SQUELCH_DB, 0.001, 10, False)
                 nbfm = analog.quadrature_demod_cf(NBFM_DEMOD_GAIN)
                 rec = SquelchRecorder(0, AUDIO_RATE_FM, VOICE_DIR, inhibited=True)
+                probe = analog.probe_avg_mag_sqrd_c(0, 0.001)
                 self.connect(self.src, xlate, rf_squelch, nbfm, rec)
+                self.connect(xlate, probe)
                 self.dyn_fm.append({
                     "xlate": xlate, "rf_squelch": rf_squelch,
-                    "nbfm": nbfm, "recorder": rec,
+                    "nbfm": nbfm, "recorder": rec, "probe": probe,
+                    "sq_state": {},
                     "freq": None, "assigned_at": None, "idx": i
                 })
 
@@ -430,6 +449,7 @@ data:
             out_dir = route_voice_dir(freq_hz)
             target["xlate"].set_center_freq(offset)
             target["recorder"].activate(freq_hz, out_dir)
+            target["sq_state"].clear()  # re-learn the noise floor at the new offset
             target["freq"] = freq_hz
             target["assigned_at"] = time.time()
             print(f"[DYN] FM slot {target['idx']} → {freq_hz/1e6:.4f} MHz ({os.path.basename(out_dir)})", flush=True)
@@ -517,6 +537,10 @@ data:
             self.src.set_center_freq(center_hz)
             with self._state_lock:
                 self.current_center_hz = center_hz
+            # Channel offsets now point at different spectrum — re-learn floors.
+            self.fixed_sq_state.clear()
+            for slot in self.dyn_fm:
+                slot["sq_state"].clear()
 
     # ---------------------------------------------------------------------------
     # FFT energy detector (background thread)
@@ -705,6 +729,68 @@ data:
                 self.tb.inhibit_recordings(RF_SETTLE_SEC)
 
     # ---------------------------------------------------------------------------
+    # Adaptive RF squelch (background thread)
+    # ---------------------------------------------------------------------------
+    class AutoSquelch(threading.Thread):
+        """Hold each FM channel's RF squelch a fixed margin above its measured noise floor.
+
+        The floor estimate follows level drops immediately and rises slowly
+        (AUTO_SQUELCH_RISE_DB per interval) while the channel is idle; it never
+        rises during a recording, so a long transmission cannot drag the
+        threshold up into itself. A steady spur becomes its channel's "floor",
+        which keeps the squelch shut on it — only power rising above the steady
+        state opens the gate.
+        """
+
+        def __init__(self, tb):
+            super().__init__(daemon=True)
+            self.tb = tb
+            self._last_log = 0.0
+            # Prior for a channel's first measurement: assume the static threshold
+            # was a sane margin above the true floor, so a channel assigned
+            # mid-transmission still opens for the in-progress signal.
+            self._floor_prior = RF_SQUELCH_DB - AUTO_SQUELCH_MARGIN_DB
+
+        def _update(self, name, probe, squelch, recorder, state):
+            level = 10.0 * math.log10(probe.level() + 1e-30)
+            floor = state.get("floor")
+            if floor is None:
+                floor = min(level, self._floor_prior)
+            elif level < floor:
+                floor = level
+            elif recorder.state != SquelchRecorder.RECORDING:
+                floor = min(floor + AUTO_SQUELCH_RISE_DB, level)
+            state["floor"] = floor
+            thr = min(max(floor + AUTO_SQUELCH_MARGIN_DB, AUTO_SQUELCH_MIN_DB),
+                      AUTO_SQUELCH_MAX_DB)
+            if state.get("thr") != thr:
+                squelch.set_threshold(thr)
+                state["thr"] = thr
+            return f"{name} lvl={level:.1f} floor={floor:.1f} thr={thr:.1f}"
+
+        def run(self):
+            time.sleep(5)  # let the flowgraph settle
+            while True:
+                try:
+                    lines = [self._update(
+                        f"{self.tb.fixed_freq/1e6:.4f}", self.tb.probe_fixed,
+                        self.tb.rf_squelch_fixed, self.tb.rec_fixed,
+                        self.tb.fixed_sq_state)]
+                    for slot in self.tb.dyn_fm:
+                        if slot["freq"] is None:
+                            continue
+                        lines.append(self._update(
+                            f"{slot['freq']/1e6:.4f}", slot["probe"],
+                            slot["rf_squelch"], slot["recorder"],
+                            slot["sq_state"]))
+                    if time.time() - self._last_log >= AUTO_SQUELCH_LOG_SEC:
+                        print(f"[SQL] {' | '.join(lines)}", flush=True)
+                        self._last_log = time.time()
+                except Exception as e:
+                    print(f"[SQL] Error: {e}", flush=True)
+                time.sleep(AUTO_SQUELCH_INTERVAL)
+
+    # ---------------------------------------------------------------------------
     # RF power monitor (background thread — logs noise floor for squelch tuning)
     # ---------------------------------------------------------------------------
     class RFPowerMonitor(threading.Thread):
@@ -748,7 +834,8 @@ data:
         print(f"  Slot tolerance: {DYN_SLOT_FREQ_TOLERANCE_HZ} Hz", flush=True)
         print(f"  FM bands:       {FM_RECORD_BANDS}", flush=True)
         print(f"  CW bands:       {CW_RECORD_BANDS}", flush=True)
-        print(f"  RF squelch:     {RF_SQUELCH_DB} dB", flush=True)
+        print(f"  RF squelch:     {RF_SQUELCH_DB} dB "
+              f"({'auto: floor+' + str(AUTO_SQUELCH_MARGIN_DB) + ' dB' if AUTO_SQUELCH else 'static'})", flush=True)
         print(f"  Scan centers:   {[f'{c/1e6:.1f}' for c in SCAN_CENTERS]} MHz", flush=True)
         print("=" * 60, flush=True)
 
@@ -765,6 +852,10 @@ data:
 
         rf_mon = RFPowerMonitor(tb)
         rf_mon.start()
+
+        if AUTO_SQUELCH:
+            auto_squelch = AutoSquelch(tb)
+            auto_squelch.start()
 
         try:
             tb.wait()

--- a/apps/radio/sdr-research/05-unified-sdr-deployment.yaml
+++ b/apps/radio/sdr-research/05-unified-sdr-deployment.yaml
@@ -71,10 +71,15 @@ spec:
             - name: SQUELCH_CLOSE_DB
               value: "-55"
             - name: RF_SQUELCH_DB
-              # Measured channel noise floor at RF_GAIN=18 is ~-49 dBFS, so -50
-              # never closed and every spur recorded 120 s noise files forever.
-              # Real NBFM traffic sits at -35 dBFS and above.
-              value: "-40"
+              # Initial threshold + floor prior only: AUTO_SQUELCH measures each
+              # channel's real noise floor and holds the squelch
+              # AUTO_SQUELCH_MARGIN_DB above it. Static values failed both ways
+              # here (-50 recorded noise 24/7; -40 recorded nothing for hours).
+              value: "-45"
+            - name: AUTO_SQUELCH_MARGIN_DB
+              # Raise if noise blips open the gate; lower if weak stations are missed.
+              # Watch the [SQL] lvl/floor/thr telemetry lines to tune from data.
+              value: "6"
             - name: NOISE_GUARD_ROLLOVERS
               # Deactivate + blocklist a channel after this many consecutive
               # max-duration rollovers (spur signature: squelch never drops).

--- a/apps/radio/sdr-research/30-deployment-api.yaml
+++ b/apps/radio/sdr-research/30-deployment-api.yaml
@@ -57,7 +57,9 @@ spec:
             - name: OLLAMA_URL
               value: "http://ollama-router.ai-stack.svc.cluster.local:11434"
             - name: OLLAMA_MODEL
-              value: "deepseek-r1:14b"
+              # deepseek-r1:14b was removed from ollama-router (every tagging
+              # call 404'd, tripping the circuit breaker). llama3.1:8b is pulled.
+              value: "llama3.1:8b"
             - name: OLLAMA_TIMEOUT_SECONDS
               value: "120"
             - name: OLLAMA_MAX_TAGS

--- a/apps/radio/sdr-research/kustomization.yaml
+++ b/apps/radio/sdr-research/kustomization.yaml
@@ -103,7 +103,8 @@ images:
   # Stage 3: delete 30a-configmap-api-overrides.yaml entirely.
   - name: registry.internal.white.fm/sdr-viewer-api
     newName: ghcr.io/w3rdw/sdr-research-api
-    newTag: "0.2.1"
+    # 0.2.2: stats/status/storage moved off the event loop (UI axios errors)
+    newTag: "0.2.2"
   - name: registry.internal.white.fm/sdr-viewer-ui
     newName: ghcr.io/w3rdw/sdr-research-ui
     newTag: "0.2.1"


### PR DESCRIPTION
Follow-up to #526 — that fix stopped the noise flood but overshot: **zero voice recordings in 7.5 h** (static −40 dBFS sits above real traffic; even APRS packets that decode fine never crossed it, while the measured floor sits just below at ~−49). Static thresholds have now failed in both directions, so the threshold becomes measured.

## Changes
- **04-unified-sdr-configmap**: sync to sdr-research-oss `unified_sdr.py` with **AutoSquelch** — per-channel `probe_avg_mag_sqrd_c` tracks the noise floor (follows drops instantly, rises slowly while idle, frozen during recordings) and holds `pwr_squelch` at floor + `AUTO_SQUELCH_MARGIN_DB` (6). `[SQL] lvl/floor/thr` telemetry every 60 s to tune the margin from data. Composes with the noise guard (steady spurs above the learned floor get blocklisted after 3 rollovers).
- **05-unified-sdr**: `RF_SQUELCH_DB` −40 → −45 (now only the initial value / floor prior); expose `AUTO_SQUELCH_MARGIN_DB`.
- **kustomization**: `sdr-research-api` 0.2.1 → **0.2.2** (built ✔ from tag). `/stats` (4.3 s), `/admin/status` (3.3 s), `/admin/storage` (5.3 s) were async handlers doing synchronous full-table scans (1.19 M rows) + 41 k-file NFS walks **on the event loop**, stalling every concurrent request — the UI's intermittent axios errors. 0.2.2 runs them in the threadpool with single-flight caches, one aggregate scan for status counters, and an O(1) heartbeat check instead of the voice-dir glob.
- **30-deployment-api**: `OLLAMA_MODEL` → `llama3.1:8b` (deepseek-r1:14b no longer exists on ollama-router; every tagging call 404'd).

## Verification path after merge
1. unified-sdr logs: `[SQL]` lines show real floor/threshold within a minute.
2. `/data/audio/voice` should start collecting real transmissions (APRS on 144.390 is the canary — it decoded ~550 packets/2 h when capture was healthy).
3. `/api/v1/stats` etc. stay responsive under concurrent load.

Merge sdr-research-oss PR #2 alongside to keep the OSS source in sync.