### PR TITLE
sdr: spur deadlock fix, noise discard, api/ui 0.2.3, HFDL+SSTV enablement

### DIFF
--- a/apps/radio/sdr-research/04-unified-sdr-configmap.yaml
+++ b/apps/radio/sdr-research/04-unified-sdr-configmap.yaml
@@ -57,6 +57,11 @@ data:
     AUTO_SQUELCH_MIN_DB     = float(os.getenv("AUTO_SQUELCH_MIN_DB", "-70"))
     AUTO_SQUELCH_MAX_DB     = float(os.getenv("AUTO_SQUELCH_MAX_DB", "-25"))
     AUTO_SQUELCH_LOG_SEC    = float(os.getenv("AUTO_SQUELCH_LOG_SEC", "60"))
+    # Demodulated FM noise is full-scale (measured ~+2.5 dB mean RMS); real voice
+    # averages well below (speech duty cycle keeps it under ~-10 dB). Discard any
+    # FM/AM recording whose whole-file mean RMS lands above this — it is
+    # guaranteed noise regardless of what the squelch thought. 100 disables.
+    NOISE_DISCARD_RMS_DB    = float(os.getenv("NOISE_DISCARD_RMS_DB", "-3"))
 
     FFT_SIZE       = int(os.getenv("FFT_SIZE", "4096"))
     FFT_INTERVAL   = float(os.getenv("FFT_INTERVAL", "1.0"))
@@ -192,8 +197,16 @@ data:
             else:
                 rms_db = 10.0 * math.log10(self._sumsq / self.samples_written + 1e-30) \
                     if self.samples_written else -300.0
-                print(f"[REC] Closed {self.current_path} "
-                      f"({self.samples_written / self.audio_rate:.1f}s, rms={rms_db:.1f} dB)", flush=True)
+                if not self.is_cw and rms_db >= NOISE_DISCARD_RMS_DB:
+                    try:
+                        os.remove(self.current_path)
+                        print(f"[REC] Discarded noise recording {self.current_path} "
+                              f"({self.samples_written / self.audio_rate:.1f}s, rms={rms_db:.1f} dB)", flush=True)
+                    except OSError:
+                        pass
+                else:
+                    print(f"[REC] Closed {self.current_path} "
+                          f"({self.samples_written / self.audio_rate:.1f}s, rms={rms_db:.1f} dB)", flush=True)
             self.wf = None
 
         def close_if_recording(self):
@@ -758,7 +771,12 @@ data:
                 floor = min(level, self._floor_prior)
             elif level < floor:
                 floor = level
-            elif recorder.state != SquelchRecorder.RECORDING:
+            elif (recorder.state != SquelchRecorder.RECORDING
+                  or recorder.consecutive_rollovers > 0):
+                # Rise while idle — and also during a recording that has already
+                # hit max duration: a carrier that never drops is a spur, and
+                # keeping the floor frozen under it would deadlock the channel
+                # open forever (the floor could never learn the spur level).
                 floor = min(floor + AUTO_SQUELCH_RISE_DB, level)
             state["floor"] = floor
             thr = min(max(floor + AUTO_SQUELCH_MARGIN_DB, AUTO_SQUELCH_MIN_DB),

--- a/apps/radio/sdr-research/05-unified-sdr-deployment.yaml
+++ b/apps/radio/sdr-research/05-unified-sdr-deployment.yaml
@@ -80,6 +80,16 @@ spec:
               # Raise if noise blips open the gate; lower if weak stations are missed.
               # Watch the [SQL] lvl/floor/thr telemetry lines to tune from data.
               value: "6"
+            - name: NOISE_DISCARD_RMS_DB
+              # Demodulated FM noise is full-scale audio (~+2.5 dB mean RMS);
+              # real voice averages far below. Anything at/above this is
+              # discarded on close — deterministic noise backstop.
+              value: "-3"
+            - name: FM_RECORD_BANDS_HZ
+              # Bandplan-true 2m FM voice only: APRS slice + repeater outputs
+              # + simplex/repeaters. The Airspy's spur forest lives at
+              # 144.4-145.1 and 145.5-146.0 where no US FM voice exists.
+              value: "144380000-144400000,145100000-145500000,146000000-148000000"
             - name: NOISE_GUARD_ROLLOVERS
               # Deactivate + blocklist a channel after this many consecutive
               # max-duration rollovers (spur signature: squelch never drops).

--- a/apps/radio/sdr-research/05b-unified-sdr-70cm-deployment.yaml
+++ b/apps/radio/sdr-research/05b-unified-sdr-70cm-deployment.yaml
@@ -76,6 +76,11 @@ spec:
               value: "3"
             - name: NOISE_GUARD_COOLDOWN_SEC
               value: "1800"
+            - name: NOISE_DISCARD_RMS_DB
+              # Demodulated FM noise is full-scale audio; real voice averages
+              # far below. Discard-on-close backstop (also forces this pod to
+              # roll onto the AutoSquelch configmap script).
+              value: "-3"
             - name: TAIL_SEC
               value: "1.5"
             - name: MIN_REC_SEC

--- a/apps/radio/sdr-research/58-ft8-wspr-decoder-deployment.yaml
+++ b/apps/radio/sdr-research/58-ft8-wspr-decoder-deployment.yaml
@@ -19,7 +19,7 @@ metadata:
   name: ft8-wspr-decoder
   namespace: sdr-research
 spec:
-  replicas: 1   # default HF workload on the directly attached RX888 node
+  replicas: 0   # parked: hf-combined (HFDL+SSTV) owns the RX888 for now — one Soapy client at a time
   strategy:
     type: Recreate
   selector:

--- a/apps/radio/sdr-research/59-hf-combined-deployment.yaml
+++ b/apps/radio/sdr-research/59-hf-combined-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
   name: hf-combined-decoder
   namespace: sdr-research
 spec:
-  replicas: 0   # keep disabled by default; enable only for dedicated HFDL/SSTV runs
+  replicas: 1   # time-shares the RX888 between HFDL + SSTV-HF (ft8-wspr parked; one Soapy client at a time)
   strategy:
     type: Recreate
   selector:

--- a/apps/radio/sdr-research/kustomization.yaml
+++ b/apps/radio/sdr-research/kustomization.yaml
@@ -103,11 +103,12 @@ images:
   # Stage 3: delete 30a-configmap-api-overrides.yaml entirely.
   - name: registry.internal.white.fm/sdr-viewer-api
     newName: ghcr.io/w3rdw/sdr-research-api
-    # 0.2.2: stats/status/storage moved off the event loop (UI axios errors)
-    newTag: "0.2.2"
+    # 0.2.3: indexer deletes whisper-confirmed-empty (noise) recordings
+    newTag: "0.2.3"
   - name: registry.internal.white.fm/sdr-viewer-ui
     newName: ghcr.io/w3rdw/sdr-research-ui
-    newTag: "0.2.1"
+    # 0.2.3: player no longer surfaces AbortError when waveform peaks arrive
+    newTag: "0.2.3"
   - name: legacycode/rtlsdr
     newTag: "latest"
   - name: ghcr.io/jvde-github/ais-catcher


### PR DESCRIPTION
Round 3 — closes the remaining noise sources found in the live `[SQL]` telemetry, fixes the player AbortError, and preps HF so it comes up the moment node-12 is powered on.

## What the telemetry showed
Adaptive squelch works on clean channels (floor ≈ −47, thr ≈ −41), but spur channels deadlocked: the floor freezes during recordings, a spur records continuously, so its floor stayed at the −51 prior (`lvl=-41.5 floor=-51.0` stuck) and the guard cycle repeated every 30 min. Meanwhile the new RMS logging showed noise files close at **+2.5 dB** mean audio RMS vs real voice far below — a deterministic discriminator.

## Fixes
- **Spur deadlock**: floor now rises during a recording that has already hit max duration — the floor learns the spur level and the gate shuts permanently.
- **Noise discard**: FM/AM recordings closing at ≥ −3 dB mean RMS are deleted on the spot (`NOISE_DISCARD_RMS_DB`).
- **Bandplan-true FM ranges (2m)**: record only 144.38–144.40 (APRS), 145.1–145.5, 146–148. The spur forest lives at 144.4–145.1/145.5–146.0 where no US FM voice exists.
- **api 0.2.3**: indexer deletes recordings whose transcript file exists but is *empty* — whisper's no-speech verdict — instead of keeping `[no transcribable audio]` junk rows forever (120 s write-grace guard).
- **ui 0.2.3**: `Failed to load audio: AbortError` fixed — the waveform-peaks query resolving mid-load re-created the player and aborted its own audio fetch. Late props no longer re-create; teardown aborts are suppressed.
- **HF/HFDL/SSTV**: `hf-combined` (time-shares the RX888 between HFDL and SSTV-HF) enabled, `ft8-wspr` parked (the RX888 SoapyRemote accepts one client). Pods sit Pending until **rke2-node-12 is powered back on** — that power-cycle is the one physical action needed for all HF modes.

env changes on both captures force the pods onto the new configmap script (70cm never rolled and still runs the pre-AutoSquelch version).

Images `api:0.2.3` / `ui:0.2.3` are building from tag `v0.2.3` — check the [tag build](https://github.com/W3RDW/sdr-research-oss/actions) is green before merging. OSS source: W3RDW/sdr-research-oss#2.