### PR TITLE
glance: add Upcoming Flights widget (jetlog) on Home

### DIFF
--- a/apps/home/glance/config/glance.yml
+++ b/apps/home/glance/config/glance.yml
@@ -647,6 +647,38 @@ pages:
   - size: small
     widgets:
     - type: custom-api
+      title: Upcoming Flights
+      title-url: https://jetlog.internal.white.fm
+      cache: 1h
+      url: http://jetlog.jetlog.svc.cluster.local:3000/api/flights
+      headers:
+        X-Authentik-Username: robert
+      parameters:
+        order: ASC
+        limit: 1000
+      template: |-
+        {{ $today := now | formatTime "dateonly" }}
+        {{ $shown := 0 }}
+        <ul class="list list-gap-10 collapsible-container" data-collapse-after="5">
+        {{ range $f := .JSON.Array "" }}
+          {{ $date := $f.String "date" }}
+          {{ if ge $date $today }}
+            {{ $shown = add $shown 1 }}
+            <li class="flex justify-between items-center gap-10">
+              <div style="min-width: 0;">
+                <div class="color-highlight text-truncate">{{ $f.String "origin.iata" }} &rarr; {{ $f.String "destination.iata" }}</div>
+                <div class="size-h6 color-subdue text-truncate">{{ $f.String "flightNumber" }}{{ $al := $f.String "airline.name" }}{{ if $al }} &middot; {{ $al }}{{ end }}</div>
+              </div>
+              <div class="shrink-0" style="text-align: right;">
+                <div>{{ $f.String "date" | parseTime "dateonly" | formatTime "Mon Jan 2" }}</div>
+                <div class="size-h6 color-subdue">{{ $f.String "departureTime" }}</div>
+              </div>
+            </li>
+          {{ end }}
+        {{ end }}
+        </ul>
+        {{ if eq $shown 0 }}<p class="color-subdue">No upcoming flights.</p>{{ end }}
+    - type: custom-api
       title: Immich Stats
       hide-header: true
       cache: 10m

--- a/platform/policy/network-policies/simple-web-apps.yaml
+++ b/platform/policy/network-policies/simple-web-apps.yaml
@@ -106,6 +106,7 @@ spec:
         - namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: uptime-kuma}}
         - namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: observability}}
         - namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: jetlog-mcp}}
+        - namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: glance}}
 
 ---
 # ======================== MYSPEED ========================


### PR DESCRIPTION
## What

Adds an **Upcoming Flights** widget to the top of the Home right-rail column, sourced from jetlog. It lists flights with `date >= today`, soonest first, collapsible after 5. Each row shows the route (`CVG → LGA`), flight number + airline, and the date + departure time.

## How

- `custom-api` widget calling the jetlog backend directly over its ClusterIP: `http://jetlog.jetlog.svc.cluster.local:3000/api/flights?order=ASC&limit=1000`.
- Auth uses jetlog's `X-Authentik-Username: robert` **trusted-header** path (`AUTH_HEADER` in the jetlog deployment) — read-only, no API key/secret required. This is jetlog's primary auth path (same header Authentik injects for the web UI).
- Filters to upcoming flights and formats dates/times in the template (`now`, `parseTime`/`formatTime "Mon Jan 2"`).

## Network policy

jetlog is `default-deny` ingress and only allowed `kube-system, authentik, uptime-kuma, observability, jetlog-mcp`. Added `glance` to the `allow-ingress` allowlist in `platform/policy/network-policies/simple-web-apps.yaml` so the widget can reach the backend. (glance egress is already `allow-all-egress`.)

## Verification

- YAML validated for both files.
- **Rendered the widget in a real Glance v0.8.5 container** against a mocked jetlog response: template compiles, past flights are excluded, future flights render soonest-first with correct dates (`Tue Jul 7`, `Mon Aug 10`), routes, times, and the airline suffix is conditional (shown when present, omitted when `null`).
- Endpoint/response shape and header-auth behavior confirmed from jetlog + jetlog-mcp source (`GET /api/flights` returns a bare array with `origin`/`destination`/`airline` always expanded as objects).
- Not yet exercised live in-cluster: `rke2-node-12` (hosting both the glance and jetlog pods) is currently flapping its kubelet/network, so cross-pod probes fail intermittently. Will confirm the rendered widget once synced.

## Notes

- Placed at the top of the Home right rail (above Immich Stats) since it's timely; easy to relocate.
- Cache is 1h.
