### PR TITLE
pages: serve public *.pages.white.fm via Authentik (v0.2.3)

### DIFF
--- a/apps/ai/pages/20-deployment.yaml
+++ b/apps/ai/pages/20-deployment.yaml
@@ -34,9 +34,12 @@ spec:
               value: "8080"
             - name: SITES_DIR
               value: "/data/sites"
-            # Serve zone: each site is hosted at https://<name>.SERVE_HOST/.
+            # Serve zone(s): each site is hosted at https://<name>.<serve-host>/.
+            # Comma-separated: the internal host plus the public, Authentik-gated
+            # host (<name>.pages.white.fm) whose outpost proxies here directly and
+            # forwards the original Host. First value is canonical (display/apex).
             - name: SERVE_HOST
-              value: "pages.internal.white.fm"
+              value: "pages.internal.white.fm,pages.white.fm"
             - name: MCP_HOST
               value: "pages-mcp.internal.white.fm"
             - name: TMPDIR

--- a/apps/ai/pages/60-networkpolicy.yaml
+++ b/apps/ai/pages/60-networkpolicy.yaml
@@ -24,6 +24,11 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: envoy-gateway-system
+        # Authentik embedded outpost proxies the public, SSO-gated
+        # <name>.pages.white.fm hosts straight to this Service.
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: authentik
       ports:
         - port: 8080
           protocol: TCP

--- a/apps/ai/pages/kustomization.yaml
+++ b/apps/ai/pages/kustomization.yaml
@@ -18,4 +18,4 @@ images:
   # Renovate bumps newTag when a new v* image is published.
   - name: registry.internal.white.fm/pages-mcp
     newName: ghcr.io/robertdwhite/pages-mcp
-    newTag: v0.2.2
+    newTag: v0.2.3


### PR DESCRIPTION
Follow-up to #537. The public route + SSO work, but Authentik's outpost forwards the **original Host** (`white-ancestry.pages.white.fm`) upstream, which the hairpin to the internal listener 404'd on (Envoy `route_not_found`).

Fix: the outpost proxies **directly to the pages Service**, and pages `v0.2.3` accepts a comma-separated `SERVE_HOST` so it serves `*.pages.white.fm` too (backward compatible; internal serving unchanged).

- `20-deployment`: `SERVE_HOST=pages.internal.white.fm,pages.white.fm`
- `kustomization`: pages-mcp `v0.2.2` -> `v0.2.3` (RobertDWhite/pages-mcp#2, image built)
- `60-networkpolicy`: allow `ns=authentik` -> `pages:8080`

Authentik provider 77 `internal_host` -> `http://pages.pages.svc.cluster.local:8080` applied live via API after this deploys.