### PR TITLE
uptime-kuma: fix crash-looping autokuma + widen flap thresholds

### DIFF
--- a/observability/uptime-kuma/42-autokuma-deployment.yaml
+++ b/observability/uptime-kuma/42-autokuma-deployment.yaml
@@ -53,11 +53,16 @@ spec:
               value: "true"
             - name: AUTOKUMA__FILES__FOLLOW_SYMLINKS
               value: "true"
+            # Down fires only after ~4.5-5 min of sustained failure
+            # (interval + 8 retries x 30s). The cluster's pod-restart /
+            # node-flap blips last 2-3.5 min and must NOT notify — the old
+            # 30s/6x10s settings alerted after ~90s and produced hundreds of
+            # down/up webhook pairs per day.
             - name: AUTOKUMA__DEFAULT_SETTINGS
               value: |-
-                *.interval: 30
-                *.max_retries: 6
-                *.retry_interval: 10
+                *.interval: 60
+                *.max_retries: 8
+                *.retry_interval: 30
           volumeMounts:
             - name: autokuma-data
               mountPath: /data

--- a/observability/uptime-kuma/kustomization.yaml
+++ b/observability/uptime-kuma/kustomization.yaml
@@ -15,9 +15,9 @@ generators:
 images:
   - name: louislam/uptime-kuma
     newTag: "2.4.0"
-  # Pinned by digest: the :master build (rev 3379fbae) ships the v3 DB
-  # migration the on-disk state requires; AutoKuma no longer publishes semver
-  # image tags (only master/latest/sha), and a digest also satisfies the
-  # cluster's require-image-digest policy.
+  # Must be >= 2.1.0-rc.1: the on-disk AutoKuma state DB is already migrated
+  # to version 3, and 2.0.0 (which the old digest pin actually resolved to)
+  # only knows version 2 and refuses to start. Plain tags are the Uptime Kuma
+  # v2 flavor (server runs 2.4.0); uptime-kuma-v1-* variants are for Kuma 1.x.
   - name: ghcr.io/bigboot/autokuma
-    digest: "sha256:8acbd3ad3ec8cb6c066aa0ee541154921283ec78159015937128541921c47974"
+    newTag: "2.1.0-rc.2"


### PR DESCRIPTION
## Why

Element/Matrix was drowning in notification noise. Over 48h, **Uptime Kuma sent ~1419 webhook deliveries** into the Matrix Status room — **84% of all cluster-generated notifications**. Two coupled root causes:

1. **AutoKuma was crash-looping** on `Database version 3 is higher than the current version (2), refusing to continue`. The image was pinned by a digest that resolves to `2.0.0` (which only knows DB v2), but the on-disk sled state DB was already migrated to v3. So AutoKuma couldn't manage any monitors.
2. **Flap thresholds were too tight.** Monitors fired `down` after ~90s (`30s interval / 6 retries × 10s`). The cluster's routine pod-restart / node-flap blips last 2–3.5 min and sailed past that threshold, spamming hundreds of down→up webhook pairs/day for slow-not-dead apps (Homarr, Monica, Shelfmark, etc.).

## What

- Bump AutoKuma `→ 2.1.0-rc.2` (Kuma-v2 flavor, matches server `2.4.0`) which ships the v3 migration, so it starts and re-manages all 109 monitors.
- Widen shared defaults `30s/6×10s → 60s/8×30s`, so `down` only fires after **~4.5–5 min** of sustained failure. Verified against AutoKuma source that `DEFAULT_SETTINGS` apply retroactively to existing monitors on reconcile.

The tag (vs digest) is safe here — the `require-image-digest` Kyverno policy is Audit-only.

## Others checked (no change)

- **Alertmanager** — already deliberately tuned (group 30m, repeat 12h, `send_resolved: false`, inhibit rules). Largest *remaining* source but it's mostly real crash-loop signal; quieting further risks hiding real problems.
- **ArgoCD notifications** — not configured, silent.
- **Media (*arr) / UniFi Protect** — external app/device notifications, preference-driven, left alone.
