### PR TITLE
hookshot/uptime-kuma: down-only + mute chronic flappers

### DIFF
--- a/apps/social/matrix-stack/hookshot/transforms/uptime-kuma.js
+++ b/apps/social/matrix-stack/hookshot/transforms/uptime-kuma.js
@@ -22,6 +22,21 @@ result = (() => {
   };
 
   if (hb) {
+    // --- noise control (fix/notification-noise) ---
+    // Uptime Kuma fires on every state change. With the widened flap thresholds
+    // the residual Status-room spam is (1) UP-recovery + PENDING-retry pings and
+    // (2) a handful of monitors that flap on transient cluster blips, not real
+    // outages. Drop both so only genuine DOWN/MAINTENANCE reaches Matrix; live
+    // state is always on the Kuma dashboard. Revert = delete this block.
+    // NOTE: this file is source-of-truth only. Hookshot reads the transform from
+    // the room's `uk.half-shot.matrix-hookshot.generic.hook` state event (state_key
+    // "Status"), so after editing you must push it into that state event for it to
+    // take effect — editing this file alone changes nothing live.
+    const MUTED = new Set(["Weather API", "LazyLibrarian", "Media MCP", "Prowlarr"]);
+    if (hb.status === 1 || hb.status === 2 || MUTED.has(mon.name)) {
+      return { version: "v2", empty: true };
+    }
+
     const states = {
       0: { word: "DOWN",        icon: "🔴" },
       1: { word: "UP",          icon: "✅" },


### PR DESCRIPTION
## Why

Follow-up to the Uptime Kuma threshold fix (#546 → main). After that landed, the
Status room went quiet, but two residual noise patterns remained, and Robert
opted for the most aggressive reduction ("down-only + mute flappers").

## What

Extends the Status-room hookshot transform (`hookshot/transforms/uptime-kuma.js`)
with a single early-return that suppresses:

- **UP (recovery) and PENDING (retry) heartbeats** — only genuine 🔴 DOWN and
  🛠 MAINTENANCE now reach Matrix. Halves volume and eliminates the
  "everything flips back at once" storm-recovery burst. Current state is always
  visible on the Kuma dashboard.
- **all heartbeats from 4 chronic flappers** — Weather API, LazyLibrarian,
  Media MCP, Prowlarr — whose blips are transient cluster churn, not real
  outages.

## Applied live (already in effect)

Hookshot reads this transform from the room's
`uk.half-shot.matrix-hookshot.generic.hook` state event (`state_key: Status`),
**not** from this file via GitOps. So it was pushed directly into that state
event (temp-admin read-modify-write, same path as `mkwebhook.sh`, preserving
`name`+`hookId` so the webhook URL is unchanged). This `.js` is the
source-of-truth copy; this PR keeps the repo in sync with what's deployed.

## Verified

Posted synthetic payloads to the live webhook:
- UP `status=1` → 202, **no** Status-room event (suppressed) ✅
- DOWN for muted `Weather API` → 202, **no** Status-room event (suppressed) ✅

## Caveat

The 4 muted monitors roll up into group monitors (Apps / Media / MCP Servers).
If one stays down >~5 min, its parent group can still emit a
"Child monitors down: X" line. Can extend suppression to strip those if it
proves noisy.
