### PR TITLE
media: add isolated flaresolverr-vpn egress pod

### DIFF
--- a/apps/media/media/18-flaresolverr-vpn.yaml
+++ b/apps/media/media/18-flaresolverr-vpn.yaml
@@ -1,0 +1,174 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: flaresolverr-vpn
+  name: flaresolverr-vpn
+  namespace: media
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: flaresolverr-vpn
+  template:
+    metadata:
+      labels:
+        app: flaresolverr-vpn
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                      - rke2-node-50
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      containers:
+        # Gluetun provides the pod's network namespace + VPN default route, and an
+        # HTTP CONNECT proxy on :8888. The sidecar shares this netns, so its outbound
+        # requests egress through the same VPN exit IP that :8888 clients get —
+        # required so any per-IP session token stays valid across both paths.
+        - name: gluetun
+          image: ghcr.io/qdm12/gluetun
+          env:
+            - name: VPN_SERVICE_PROVIDER
+              value: private internet access
+            - name: VPN_TYPE
+              value: openvpn
+            - name: SERVER_REGIONS
+              value: US East,US Atlanta,US Chicago,US Denver,US East Streaming Optimized,US California,US Washington DC,US New York,US Las Vegas
+            - name: UPDATER_PERIOD
+              value: 24h
+            - name: HTTPPROXY
+              value: "on"
+            - name: HTTPPROXY_LOG
+              value: "off"
+            - name: SHADOWSOCKS
+              value: "off"
+            - name: FIREWALL_INPUT_PORTS
+              value: 8000,8888,8191
+            - name: FIREWALL_OUTBOUND_SUBNETS
+              value: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+            - name: OPENVPN_USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: vpn-credentials
+            - name: OPENVPN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: vpn-credentials
+          ports:
+            - containerPort: 8888
+              name: http-proxy
+          startupProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /v1/openvpn/status
+              port: 8000
+            periodSeconds: 10
+          livenessProbe:
+            failureThreshold: 3
+            periodSeconds: 60
+            timeoutSeconds: 15
+            exec:
+              command:
+                - sh
+                - -c
+                - wget -q -O /dev/null --tries=1 --timeout=10 -e use_proxy=yes -e https_proxy=http://127.0.0.1:8888 https://www.google.com/generate_204
+          readinessProbe:
+            failureThreshold: 2
+            periodSeconds: 30
+            timeoutSeconds: 10
+            exec:
+              command:
+                - sh
+                - -c
+                - wget -q -O /dev/null --tries=1 --timeout=8 -e use_proxy=yes -e https_proxy=http://127.0.0.1:8888 https://www.google.com/generate_204
+          resources:
+            limits:
+              cpu: "1"
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+          volumeMounts:
+            - mountPath: /dev/net/tun
+              name: tun
+        - name: flaresolverr
+          image: ghcr.io/flaresolverr/flaresolverr
+          env:
+            - name: LOG_LEVEL
+              value: info
+            - name: HOST
+              value: 0.0.0.0
+            - name: PORT
+              value: "8191"
+            - name: TZ
+              value: America/New_York
+          ports:
+            - containerPort: 8191
+              name: flaresolverr
+          startupProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /
+              port: 8191
+            periodSeconds: 10
+          livenessProbe:
+            failureThreshold: 3
+            periodSeconds: 60
+            timeoutSeconds: 10
+            httpGet:
+              path: /
+              port: 8191
+          readinessProbe:
+            failureThreshold: 3
+            periodSeconds: 30
+            timeoutSeconds: 10
+            httpGet:
+              path: /
+              port: 8191
+          resources:
+            limits:
+              cpu: "1"
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: dshm
+      volumes:
+        - hostPath:
+            path: /dev/net/tun
+            type: CharDevice
+          name: tun
+        - emptyDir:
+            medium: Memory
+            sizeLimit: 256Mi
+          name: dshm
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flaresolverr-vpn
+  namespace: media
+spec:
+  ports:
+    - name: http-proxy
+      port: 8888
+      targetPort: 8888
+    - name: flaresolverr
+      port: 8191
+      targetPort: 8191
+  selector:
+    app: flaresolverr-vpn

--- a/apps/media/media/19-netpol-flaresolverr-vpn.yaml
+++ b/apps/media/media/19-netpol-flaresolverr-vpn.yaml
@@ -1,0 +1,23 @@
+# Lets the flaresolverr-vpn pod's gluetun reach the VPN server and egress to the
+# internet through the tunnel. Mirrors allow-vpn-egress (11-netpol.sops.yaml).
+# In-namespace clients -> flaresolverr-vpn are already covered by
+# allow-intra-namespace; DNS by allow-dns.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-flaresolverr-vpn-egress
+  namespace: media
+spec:
+  podSelector:
+    matchLabels:
+      app: flaresolverr-vpn
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16

--- a/apps/media/media/kustomization.yaml
+++ b/apps/media/media/kustomization.yaml
@@ -10,6 +10,8 @@ resources:
   - 14-netpol-calibre-lazylibrarian.yaml
   - 15-netpol-searxng-to-vpn.yaml
   - 16-netpol-calibre-shelfmark-to-vpn.yaml
+  - 18-flaresolverr-vpn.yaml
+  - 19-netpol-flaresolverr-vpn.yaml
   - 30-exportarr.yaml
 
 generators:
@@ -18,5 +20,7 @@ generators:
 images:
   - name: ghcr.io/qdm12/gluetun
     newTag: "v3.41.1"
+  - name: ghcr.io/flaresolverr/flaresolverr
+    newTag: "v3.5.0"
   - name: ghcr.io/onedr0p/exportarr
     newTag: "v2.3.0"


### PR DESCRIPTION
## What

Adds a self-contained `flaresolverr-vpn` pod to the `media` namespace:

- **gluetun** VPN-egress sidecar — its own connection, reuses the existing `vpn-credentials` secret; HTTP CONNECT proxy on `:8888`.
- **flaresolverr v3.5.0** headless-browser helper sharing the pod's network namespace, on `:8191`.
- `Service` exposing `:8888` + `:8191`; `NetworkPolicy` for the pod's egress (mirrors `allow-vpn-egress`).

Both share one VPN exit IP, which is required so any per-IP session token stays valid across the proxy and the helper.

Kept separate from the shared `vpn-proxy` deployment on purpose — that pod is load-bearing for cluster DNS and shouldn't carry this workload.

## Validation
- `kubectl kustomize --enable-alpha-plugins apps/media/media` renders clean (22 docs); images pin to `gluetun:v3.41.1` + `flaresolverr:v3.5.0`.
- gluetun spec mirrors the existing `vpn-proxy` deployment (probes, `NET_ADMIN`, `/dev/net/tun`, node constraints).
