### PR TITLE
glance: expand home dashboard bookmarks (apps + pages)

### DIFF
--- a/apps/home/glance/config/glance.yml
+++ b/apps/home/glance/config/glance.yml
@@ -437,6 +437,9 @@ pages:
         - title: Filebot
           url: https://filebot.internal.white.fm
           icon: di:filebot
+        - title: FlexGet
+          url: https://flexget.internal.white.fm
+          icon: di:flexget
       - title: Books & Reading
         links:
         - title: Kavita
@@ -492,6 +495,8 @@ pages:
           icon: di:searxng
         - title: Odysseus
           url: https://odysseus.internal.white.fm
+        - title: Hermes
+          url: https://hermes.internal.white.fm
       - title: Intelligence & Security
         links:
         - title: MISP
@@ -582,22 +587,53 @@ pages:
         - title: Nitter
           url: https://nitter.internal.white.fm
           icon: di:nitter
+        - title: Nodebyte
+          url: https://nodebyte.internal.white.fm
+        - title: Card Optimizer
+          url: https://cards.internal.white.fm
+        - title: Gibt es Gott?
+          url: https://gibt-es-gott.internal.white.fm
+        - title: Homepage
+          url: https://homepage.internal.white.fm
+          icon: di:homepage
       - title: Pages
         links:
         - title: Index
           url: https://pages.internal.white.fm
-        - title: DARK Psychology Trainer
-          url: https://dark-psychology-trainer.pages.internal.white.fm
+        - title: White Ancestry
+          url: https://white-ancestry.pages.internal.white.fm
         - title: Job Pipeline Tracker
           url: https://jobs.pages.internal.white.fm
         - title: MSP Outreach Dashboard
           url: https://msp-outreach.pages.internal.white.fm
         - title: Robinhood $100 Challenge
           url: https://robinhood.pages.internal.white.fm
-        - title: VOSS Negotiation Trainer
-          url: https://voss-trainer.pages.internal.white.fm
         - title: Wallace & White Client Map
           url: https://ww-client-map.pages.internal.white.fm
+      - title: Book Trainers
+        links:
+        - title: Book Trainers Hub
+          url: https://book-trainers.pages.internal.white.fm
+        - title: VOSS Negotiation Trainer
+          url: https://voss-trainer.pages.internal.white.fm
+        - title: DARK Psychology Trainer
+          url: https://dark-psychology-trainer.pages.internal.white.fm
+        - title: 48 Laws of Power Trainer
+          url: https://48-laws-of-power.pages.internal.white.fm
+        - title: 7 Rules of Power Trainer
+          url: https://7-rules-of-power.pages.internal.white.fm
+        - title: Dare to Lead Trainer
+          url: https://dare-to-lead.pages.internal.white.fm
+        - title: The Effective Executive Trainer
+          url: https://effective-executive.pages.internal.white.fm
+        - title: Financial Intelligence Trainer
+          url: https://financial-intelligence.pages.internal.white.fm
+        - title: The First 90 Days Trainer
+          url: https://first-90-days.pages.internal.white.fm
+        - title: The Lifegiving Parent Trainer
+          url: https://lifegiving-parent.pages.internal.white.fm
+        - title: Selling to the C-Suite Trainer
+          url: https://selling-to-c-suite.pages.internal.white.fm
       - title: Downloads
         links:
         - title: Prowlarr


### PR DESCRIPTION
Adds bookmark links to the Glance home dashboard for recently deployed internal apps and for the static pages sites currently served, so the dashboard covers everything running.

- New app bookmarks across the relevant groups.
- New 'Book Trainers' bookmark group for the trainer pages.
- Pages group now reflects the sites actually served from the pages volume.

No secret/env changes — bookmark links only. YAML validated.