### PR TITLE
media: expand sonarr-config PVC 2Gi->5Gi

### DIFF
--- a/apps/media/media/05-b.sops.yaml
+++ b/apps/media/media/05-b.sops.yaml
@@ -8,7 +8,7 @@ spec:
         - ENC[AES256_GCM,data:AGGOy1xrQWgmdxLSow==,iv:ve3zoNLe5Y5ULDdweve6LvOvrkaU0y1Cv8/rTD2e0yw=,tag:NKA1Kjxdm9sfulY5vsecaQ==,type:str]
     resources:
         requests:
-            storage: ENC[AES256_GCM,data:523h,iv:5PSZfo3BjB3ALGNyhzIF+4zHjFAqAb0vqppjYzl6ew4=,tag:OqhjVVjHUutc9cEvM58ESQ==,type:str]
+            storage: ENC[AES256_GCM,data:mOXY,iv:hq+3WY2vAjB1MM2KbfjlXNE+BAfdOR03dpqGBymSAS4=,tag:KKahfE0C39UfhNY20g22Qw==,type:str]
     storageClassName: ENC[AES256_GCM,data:LzRyzadNQb0=,iv:62aZyoSwASGxk7tbp3r2N8m3XI+sNG2qzszRwnQsrgM=,tag:h6pSeByX1QiB3OUs/ePsNw==,type:str]
 sops:
     age:
@@ -21,8 +21,8 @@ sops:
             aHBoWWpodVhDYnFIY0RuWVIySmZ4TkUK4zr6+wjqT47xXGkUX8podxf+DsWNZqXx
             f1Vv2/PRCqlpaduKGgQvPKZH3jlei/S6eZJsom5AMI7xGyNG0xDgEA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-07-11T06:01:21Z"
-    mac: ENC[AES256_GCM,data:WRjsQTTBdsrc6QxcinQNv1da4m06M2uqu+xstnAVyju6uQF2HTAat+8K7J95cC5dBJXVc8kpiRdfxphHZT6UH0os9zb92fk6AOjtWX3aC9j9Ajo7KuqqHY20QfQO0nwg11g8H0AUUfMOT+o3YJ33OGAjktzB6rVzPYylTenj580=,iv:ba/RZb2JEgRATJk5kpvClGqSqZdWfqUIq8SC8mNek48=,tag:QjmGWdtCzbsyjglPQoumrw==,type:str]
+    lastmodified: "2026-07-12T05:15:54Z"
+    mac: ENC[AES256_GCM,data:rANBBATd5uCJe3DYtPjUuDJpb7bmd+RwYmKK7BG4+kTKF8RoCpa7nEpYOioywqPPSqlPJ1wSOod7ch/+7MLth6jGLRpTlyHoIiBko5eqZkX0L4JeD7U2gysI47gq8+m1/cRro4YZjLkg8AaHa1PjkZX89KLIR+9SVk56b8nDUXA=,iv:0GTIdzn0NIN9LpWG40+kKf4p6CYZq7mF9qvMn23RYLE=,tag:LpG54aCdsIAA8L5T5gFNuw==,type:str]
     encrypted_regex: ^(.*)$
     version: 3.10.2
 ---
@@ -123,8 +123,8 @@ sops:
             aHBoWWpodVhDYnFIY0RuWVIySmZ4TkUK4zr6+wjqT47xXGkUX8podxf+DsWNZqXx
             f1Vv2/PRCqlpaduKGgQvPKZH3jlei/S6eZJsom5AMI7xGyNG0xDgEA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-07-11T06:01:21Z"
-    mac: ENC[AES256_GCM,data:WRjsQTTBdsrc6QxcinQNv1da4m06M2uqu+xstnAVyju6uQF2HTAat+8K7J95cC5dBJXVc8kpiRdfxphHZT6UH0os9zb92fk6AOjtWX3aC9j9Ajo7KuqqHY20QfQO0nwg11g8H0AUUfMOT+o3YJ33OGAjktzB6rVzPYylTenj580=,iv:ba/RZb2JEgRATJk5kpvClGqSqZdWfqUIq8SC8mNek48=,tag:QjmGWdtCzbsyjglPQoumrw==,type:str]
+    lastmodified: "2026-07-12T05:15:54Z"
+    mac: ENC[AES256_GCM,data:rANBBATd5uCJe3DYtPjUuDJpb7bmd+RwYmKK7BG4+kTKF8RoCpa7nEpYOioywqPPSqlPJ1wSOod7ch/+7MLth6jGLRpTlyHoIiBko5eqZkX0L4JeD7U2gysI47gq8+m1/cRro4YZjLkg8AaHa1PjkZX89KLIR+9SVk56b8nDUXA=,iv:0GTIdzn0NIN9LpWG40+kKf4p6CYZq7mF9qvMn23RYLE=,tag:LpG54aCdsIAA8L5T5gFNuw==,type:str]
     encrypted_regex: ^(.*)$
     version: 3.10.2
 ---
@@ -151,7 +151,7 @@ sops:
             aHBoWWpodVhDYnFIY0RuWVIySmZ4TkUK4zr6+wjqT47xXGkUX8podxf+DsWNZqXx
             f1Vv2/PRCqlpaduKGgQvPKZH3jlei/S6eZJsom5AMI7xGyNG0xDgEA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-07-11T06:01:21Z"
-    mac: ENC[AES256_GCM,data:WRjsQTTBdsrc6QxcinQNv1da4m06M2uqu+xstnAVyju6uQF2HTAat+8K7J95cC5dBJXVc8kpiRdfxphHZT6UH0os9zb92fk6AOjtWX3aC9j9Ajo7KuqqHY20QfQO0nwg11g8H0AUUfMOT+o3YJ33OGAjktzB6rVzPYylTenj580=,iv:ba/RZb2JEgRATJk5kpvClGqSqZdWfqUIq8SC8mNek48=,tag:QjmGWdtCzbsyjglPQoumrw==,type:str]
+    lastmodified: "2026-07-12T05:15:54Z"
+    mac: ENC[AES256_GCM,data:rANBBATd5uCJe3DYtPjUuDJpb7bmd+RwYmKK7BG4+kTKF8RoCpa7nEpYOioywqPPSqlPJ1wSOod7ch/+7MLth6jGLRpTlyHoIiBko5eqZkX0L4JeD7U2gysI47gq8+m1/cRro4YZjLkg8AaHa1PjkZX89KLIR+9SVk56b8nDUXA=,iv:0GTIdzn0NIN9LpWG40+kKf4p6CYZq7mF9qvMn23RYLE=,tag:LpG54aCdsIAA8L5T5gFNuw==,type:str]
     encrypted_regex: ^(.*)$
     version: 3.10.2


### PR DESCRIPTION
## What
Bump the `sonarr-config` RWO Longhorn PVC from **2Gi -> 5Gi** (parity with `radarr-config`).

## Why
Sonarr crash-looped (`exit 137`, liveness SIGKILL) after its 2Gi config volume hit 100%. Root cause: a runaway `logs.db` (726M + 457M WAL) driven by a broken import loop filled the volume, so Sonarr's startup write-test failed (`/config is not writable, No space left on device`). Freed space live to restore service; this is the durable headroom fix. 2Gi was undersized vs radarr's 5Gi.

## Change
- `apps/media/media/05-b.sops.yaml`: `storage: 2Gi` -> `5Gi` (single value, in-place SOPS set; no plaintext exposed)

## Notes
- Longhorn StorageClass allows volume expansion, so this is an online resize on sync.
- Follow-up (separate): clear the ~1k stalled/orphaned queue items feeding the log spam.