### PR TITLE
gibt-es-gott: sync content from private repo via initContainer

### DIFF
--- a/apps/misc/gibt-es-gott/10-deployment.yaml
+++ b/apps/misc/gibt-es-gott/10-deployment.yaml
@@ -15,6 +15,73 @@ spec:
       labels:
         app: gibt-es-gott
     spec:
+      initContainers:
+        # Pull the site content from the private repo RobertDWhite/gibt-es-gott into
+        # the PVC on every (re)start. Text/HTML is synced whenever the repo HEAD changes;
+        # the large LFS videos are fetched only when absent (so routine restarts are cheap
+        # but a blank PVC self-heals fully from git). Best-effort: if GitHub is unreachable
+        # nginx still serves whatever is already in the PVC.
+        - name: content-sync
+          image: alpine/git
+          env:
+            - name: GIT_REMOTE
+              value: "ssh://git@ssh.github.com:443/RobertDWhite/gibt-es-gott.git"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -u
+              echo "[content-sync] starting"
+              printf '%s\n' \
+                'github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl' \
+                '[ssh.github.com]:443 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl' > /tmp/known_hosts
+              export GIT_SSH_COMMAND="ssh -i /keys/id_ed25519 -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=/tmp/known_hosts"
+              export GIT_LFS_SKIP_SMUDGE=1
+              TMP=/tmp/repo
+              rm -rf "$TMP"
+              if ! git clone --depth 1 "$GIT_REMOTE" "$TMP"; then
+                echo "[content-sync] clone failed; serving existing PVC content"; exit 0
+              fi
+              NEWSHA="$(git -C "$TMP" rev-parse HEAD)"
+              OLDSHA="$(cat /content/.synced-sha 2>/dev/null || echo none)"
+              if [ "$NEWSHA" != "$OLDSHA" ]; then
+                echo "[content-sync] syncing text @ $NEWSHA (was $OLDSHA)"
+                for f in "$TMP"/site/*; do
+                  case "$f" in *.mp4) continue ;; esac
+                  cp "$f" /content/
+                done
+                printf '%s\n' "$NEWSHA" > /content/.synced-sha
+              else
+                echo "[content-sync] text already @ $NEWSHA"
+              fi
+              NEED=""
+              for v in part1.mp4 part2.mp4 part3.mp4; do
+                [ -s "/content/$v" ] || NEED="$NEED $v"
+              done
+              if [ -n "$NEED" ]; then
+                echo "[content-sync] missing videos:$NEED - fetching via LFS"
+                if apk add --no-cache git-lfs >/dev/null 2>&1; then
+                  git -C "$TMP" lfs install --local >/dev/null 2>&1 || true
+                  for v in $NEED; do
+                    if git -C "$TMP" lfs pull --include "site/$v" && [ -s "$TMP/site/$v" ]; then
+                      cp "$TMP/site/$v" /content/ && echo "[content-sync]   $v ok"
+                    else
+                      echo "[content-sync]   $v FAILED (left absent)"
+                    fi
+                  done
+                else
+                  echo "[content-sync] git-lfs install failed; skipping videos"
+                fi
+              fi
+              echo "[content-sync] done"
+          volumeMounts:
+            - name: content
+              mountPath: /content
+            - name: git-key
+              mountPath: /keys
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
       containers:
         - name: nginx
           image: nginx
@@ -57,6 +124,10 @@ spec:
         - name: content
           persistentVolumeClaim:
             claimName: gibt-es-gott-content
+        - name: git-key
+          secret:
+            secretName: gibt-es-gott-git
+            defaultMode: 0400
         - name: nginx-conf
           configMap:
             name: nginx-conf

--- a/apps/misc/gibt-es-gott/12-secret-git.sops.yaml
+++ b/apps/misc/gibt-es-gott/12-secret-git.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: gibt-es-gott-git
+    namespace: gibt-es-gott
+type: Opaque
+stringData:
+    id_ed25519: ENC[AES256_GCM,data:33zZco86vgLv9Dd3hCjAnlkDcDO9+RDIcMgNGYjOLDThYz+mBHpnvI7yYgQ2ce7BaA9Chc7925iXZwW3OFvAF+mgFrfMQ16q0OxCqWNpdm7CmQdSkIgvJGZ8wEl2smtU4w2l1Fosad24+Ipw/TMMZC8vdGEayWPyNZkN2A8B/tVxWpvAwadq/dtlyy13pOIA+QAKcE3au5tWujaXbxHcRPzY/49/RvsbcCGOJDtZBjhJxyWnQ+tWgwm3D63KTVbrD1ynuPMMMLxUMThxzooCPXsvx+UoJeEu9iw9NvO9yV0Sm0MymJcVfUcXyQ/20nZM89c4gKC334jHtm++njtpVZpND29hsJ9dxlQ5o4hHPIrJlZQXL51QSpH+ShbciW5PO0HoHsBWlPGv3a2smtdv+2lvC0DqRFsysM0dEvBf71qeu84wMim/ISLVT35UvysApVLrN8u2OLWAgz/usM6tDUXB0hXIQFCEzdCuRvH2xSk3H70JhzlNZROGsAkg28oO7sYkDw531Wkpd2JsW3h/KHC63DsgqCqd5AadTu0cOGbpiKH/2/4QAYB9E1OcJTI+MdVvWyKZMGU9Zagqa79+GKSWXUE=,iv:c5/mncpL3IG43KSr4I3X2nEudtbPDTdv3a+6qcM46Uk=,tag:OPa/FRaaoUfyR+Q4wcWKvw==,type:str]
+sops:
+    age:
+        - recipient: age16krjysalsq26mfndnthd9r42thapj43a0zdndgrrz30utzuhwd0q7fxh9p
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJdUV2ei9EZk95NkQwNTZP
+            UHRPRHByaTU1RGR1L3l2eUdSY2R5cE5UZXlBCnV3S0N2d25NcU1tcWh4UUIzb1ZO
+            NWFoNkJNdVVraVdYLzJ6dnFSVFRjeVEKLS0tIEpaSWV6ZjM1WlduMUhTbDRDMXk3
+            b3Yya2JMVzIrc09UcDZhampsdUNEejQKYxctpNYShMTyutlVoSMblT3WtK5heajR
+            kx102sq0z+71mio4w1Td79kiQ9MMCWFi3wUxgTay3ZIfNtKrrtt5iw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-12T05:45:13Z"
+    mac: ENC[AES256_GCM,data:thh1L3s54h0harcbsCve6zW6tWjlpf9T37Ep2x15Pk4mlRaSBEGpk4DZ6WONjzuueyVamVCXSseuSDmA4pYBjwpRWafXl9g635JPcORaRXt7ycZ+vn3eqwg2+RU0AI604Gm+P43DQNR/gh/89jlOQnv6u0maclb6XNSuxZHswQA=,iv:TyTRr6E/nv5OPJwnLSE/qf7ArEqVzAQDvA6kvIW0uXQ=,tag:DQKbrJGM3J06Q11v8ak0jA==,type:str]
+    encrypted_regex: ^(data|stringData|parameters)$
+    version: 3.10.2

--- a/apps/misc/gibt-es-gott/ksops.yaml
+++ b/apps/misc/gibt-es-gott/ksops.yaml
@@ -1,0 +1,10 @@
+apiVersion: viaduct.ai/v1
+kind: Ksops
+metadata:
+  name: gibt-es-gott-secret-generator
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+files:
+  - 12-secret-git.sops.yaml

--- a/apps/misc/gibt-es-gott/kustomization.yaml
+++ b/apps/misc/gibt-es-gott/kustomization.yaml
@@ -10,6 +10,12 @@ resources:
   - 52-httproute-public.yaml
   - 53-httproute-internal.yaml
 
+generators:
+  - ksops.yaml
+
 images:
   - name: nginx
     newTag: "1.31-alpine"
+  # content-sync initContainer; pinned by digest (alpine/git:2.47.2)
+  - name: alpine/git
+    digest: sha256:062a01ad7a0eb17cff382bc5e26086b4d710e56dfdfdf001109a49b6d9bd378c


### PR DESCRIPTION
## What
Closes the GitOps loop for the `gibt-es-gott` site content. Until now the manifests were GitOps'd but the content (`index.html`, transcripts, videos) was hand-copied into the Longhorn PVC. This adds an `alpine/git` initContainer that pulls the content from the private repo `RobertDWhite/gibt-es-gott` on each pod (re)start.

## How
- **Text/HTML**: synced whenever the private repo HEAD changes (keyed on a `/content/.synced-sha` marker) — cheap no-op when unchanged.
- **Videos (LFS, ~446MB)**: fetched only when absent, so routine restarts don't re-pull them; a blank PVC still self-heals fully from git.
- **Best-effort**: if GitHub is unreachable the initContainer exits 0 and nginx serves whatever is already in the PVC (no outage).
- **Auth**: read-only SSH deploy key over `ssh://git@ssh.github.com:443/…`, stored SOPS-encrypted and wired via a `ksops` generator (mirrors `apps/ai/pages`). Host key pinned; `alpine/git` pinned by digest. Namespace egress already open.

## Verification
- `kustomize build --enable-alpha-plugins --enable-exec` renders clean (secret decrypts, images pin, initContainer mounts content RW / nginx RO, `defaultMode 0400`).
- The read-only deploy key was tested end-to-end from outside the cluster: SSH-over-443 clone + `git lfs pull` of a video (sha256 verified).

Content sync goes live on merge + ArgoCD sync (the `Recreate` rollout runs the initContainer once).
