### PR TITLE
lazylibrarian: node anti-affinity to avoid flaky rke2-node-14

### DIFF
--- a/apps/media/lazylibrarian/71-deployment-lazylibrarian.yaml
+++ b/apps/media/lazylibrarian/71-deployment-lazylibrarian.yaml
@@ -15,6 +15,15 @@ spec:
       labels:
         app: lazylibrarian
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                      - rke2-node-14
       containers:
         - name: lazylibrarian
           image: lscr.io/linuxserver/lazylibrarian:latest


### PR DESCRIPTION
Keeps the lazylibrarian pod off rke2-node-14 (which fails RWO Longhorn attaches) via required nodeAffinity NotIn rke2-node-14. Rescued from an orphaned worktree.