### PR TITLE
observability: enable SQLite WAL for Grafana

### DIFF
--- a/observability/observability/12-deploy-grafana.yaml
+++ b/observability/observability/12-deploy-grafana.yaml
@@ -43,6 +43,12 @@ spec:
             # admin password to "admin".
             - name: GF_SERVER_ROOT_URL
               value: "https://grafana.white.fm"
+            # SQLite (grafana.db) lives on the Longhorn-backed grafana-data
+            # PVC. Enable WAL so reads do not block the single writer; without
+            # it, Grafana 13's concurrent writers trigger "database is locked
+            # (SQLITE_BUSY)" storms that 500 /api/search and stall dashboards.
+            - name: GF_DATABASE_WAL
+              value: "true"
             - name: GF_MISP_INFLUX_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Problem
Grafana dashboards intermittently fail to load (`/api/search` returns 500). Root cause is Grafana's database, not any client.

Grafana 13.1.0 uses **SQLite** (`/var/lib/grafana/grafana.db`) on the **Longhorn**-backed `grafana-data` PVC, with **WAL journaling off** (Grafana default — no `GF_DATABASE_*` set). Under Grafana 13's concurrent writers (unified-storage job drivers, alerting scheduler, dashboard provisioning), this causes constant:

```
database is locked (5) (SQLITE_BUSY)
… /api/search status=500 … sqlstore.max-retries-reached … duration=7.1s
```

Every SQLite fsync pays Longhorn replication latency, and without WAL, reads block the single writer — so `/api/search` waits ~7s on the lock and 500s.

## Fix
Set `GF_DATABASE_WAL=true` on the grafana container. WAL lets readers proceed without blocking the writer, which clears the `SQLITE_BUSY` storm. One env var, reversible, effective on the next (Recreate) rollout.

ArgoCD auto-sync (selfHeal) will apply this on merge — no manual sync needed. Expect a brief Grafana restart as it rolls.

## Follow-up (not in this PR)
Migrate Grafana's DB off SQLite/Longhorn to **Postgres** to eliminate single-writer contention entirely — the durable fix for a busy Grafana.

Note: commit is unsigned (1Password signing was locked at authoring time).