### PR TITLE
observability: migrate Grafana DB from SQLite to Postgres

### DIFF
--- a/observability/observability/12-deploy-grafana.yaml
+++ b/observability/observability/12-deploy-grafana.yaml
@@ -100,6 +100,26 @@ spec:
                   key: GF_RENDERING_AUTH_TOKEN
             - name: GF_LOG_FILTERS
               value: "rendering:debug"
+            # Database: external Postgres (grafana-postgres StatefulSet)
+            # replaces default SQLite on Longhorn, which lock-thrashed
+            # (SQLITE_BUSY) under Grafana 13 concurrent writers and 500'd
+            # /api/search. Dashboards/datasources are file-provisioned so
+            # they survive; SA tokens/users are recreated on the fresh DB.
+            - name: GF_DATABASE_TYPE
+              value: "postgres"
+            - name: GF_DATABASE_HOST
+              value: "grafana-postgres:5432"
+            - name: GF_DATABASE_NAME
+              value: "grafana"
+            - name: GF_DATABASE_USER
+              value: "grafana"
+            - name: GF_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-postgres
+                  key: POSTGRES_PASSWORD
+            - name: GF_DATABASE_SSL_MODE
+              value: "disable"
           volumeMounts:
             - name: data
               mountPath: /var/lib/grafana

--- a/observability/observability/28-secret-grafana-postgres.sops.yaml
+++ b/observability/observability/28-secret-grafana-postgres.sops.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: grafana-postgres
+    namespace: observability
+type: Opaque
+stringData:
+    POSTGRES_DB: ENC[AES256_GCM,data:MvxCUPZdFg==,iv:yrs+1EiQ71ilYRN4YTxWlkL+g2gDhNtLfhBbpf4XU10=,tag:IEYrWdDn6XvZAkBtbRvC/Q==,type:str]
+    POSTGRES_USER: ENC[AES256_GCM,data:n5MP60fYHQ==,iv:+5ZpEwx2BK70n+bRr6FZoWt0VOwJNT24hx4i1WwV1Mk=,tag:UZqhTTc/e+rMbB5p6dIgaQ==,type:str]
+    POSTGRES_PASSWORD: ENC[AES256_GCM,data:yw+TF1m38ORRvA0H2g6pYHt+wAWiYugVWHef8o64ZearxcK25NGfkd1KZ092vRoh,iv:uYk1ZP32T77jttHZaux0Q2jSmpJYzczrFJMdOQ3xn2U=,tag:syf15Lo/r52gdn/115OLPA==,type:str]
+sops:
+    age:
+        - recipient: age16krjysalsq26mfndnthd9r42thapj43a0zdndgrrz30utzuhwd0q7fxh9p
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKL3IxWVRIcU9aK1RidEcr
+            dldPYWdCU2pFU3ZZalZma21HRWd6K0xTMWt3Cldqc2s4NHh2S0ROU3hVL3BPWUpp
+            VWdRZThLcENyM25GTFZSZWR5NkFpaVUKLS0tIHlGRGZEOHkxL2RsUDEzdk1wWkQ1
+            UmFQZzJWVEZtT2Nwb2tPN3ZKekhaQXMK1lw1QCU+lbZBoDGPhbErbQ3q6i2qO0I6
+            NuJiFzpMcIZzjl808Kpz3ZVpkQGUz95iM1cRTEMkHsQN5wCuBnW6yA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-13T04:02:21Z"
+    mac: ENC[AES256_GCM,data:ZotNGiDld27bV+EqKO7PaIgVTBPTynXrEqpnLKDdE/lnAvHb7SYAdaJHCW2Dt6NmCtnU+x724cxmYZOYKWBHtzobAcHiFvnnx0eqOSDLqK+O+8k+MSW3HZsLSjrEM9Tpx/TPUKWpqnCX6zuzQ+fWq3LIzZzJuaLAqtJvXLcwWOA=,iv:YMSXD2hPdvzlpa1D6u7ySEENUpTN/gYebT8PFO0ROec=,tag:SP95Jwhpu6tzqLZQ8hG8/A==,type:str]
+    encrypted_regex: ^(data|stringData|parameters)$
+    version: 3.10.2

--- a/observability/observability/28a-statefulset-grafana-postgres.yaml
+++ b/observability/observability/28a-statefulset-grafana-postgres.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: grafana-postgres
+  namespace: observability
+spec:
+  replicas: 1
+  serviceName: grafana-postgres
+  selector:
+    matchLabels:
+      app: grafana-postgres
+  template:
+    metadata:
+      labels:
+        app: grafana-postgres
+    spec:
+      nodeSelector:
+        observability: "true"
+      containers:
+        - name: postgres
+          image: postgres
+          ports:
+            - containerPort: 5432
+          envFrom:
+            - secretRef:
+                name: grafana-postgres
+          env:
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "grafana", "-d", "grafana"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "grafana", "-d", "grafana"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: 10Gi

--- a/observability/observability/28b-svc-grafana-postgres.yaml
+++ b/observability/observability/28b-svc-grafana-postgres.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-postgres
+  namespace: observability
+spec:
+  selector:
+    app: grafana-postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/observability/observability/ksops.yaml
+++ b/observability/observability/ksops.yaml
@@ -15,3 +15,4 @@ files:
   - 100-secret-pihole-exporter-a.sops.yaml
   - 102-secret-pihole-exporter-b.sops.yaml
   - 103-secret-pihole-exporter-c.sops.yaml
+  - 28-secret-grafana-postgres.sops.yaml

--- a/observability/observability/kustomization.yaml
+++ b/observability/observability/kustomization.yaml
@@ -59,6 +59,11 @@ resources:
   # Restrict grafana:3000 ingress to the Authentik outpost (auth-proxy spoofing)
   - 27-networkpolicy-grafana.yaml
 
+  # Grafana database (external Postgres StatefulSet, replaces SQLite)
+  # 28-secret-grafana-postgres.sops.yaml is loaded via ksops.yaml generator
+  - 28a-statefulset-grafana-postgres.yaml
+  - 28b-svc-grafana-postgres.yaml
+
   # Unifi Poller
   - 41-deploy-unifi-poller.yaml
   - 42-svc-unifi-poller.yaml
@@ -185,3 +190,6 @@ images:
 
   - name: ghcr.io/alexbakker/alertmanager-ntfy
     newTag: "1.2.1"
+
+  - name: postgres
+    newTag: "17-alpine"


### PR DESCRIPTION
## Why
Grafana dashboards intermittently fail to load — root cause is Grafana's DB. Grafana 13.1.0 runs on **SQLite** (`grafana.db`) on a **Longhorn** PVC with WAL off. Under Grafana 13's concurrent writers (unified-storage job drivers, alerting, provisioning), SQLite lock-thrashes:
```
database is locked (5) (SQLITE_BUSY) … /api/search status=500 … duration=7.1s
```
SQLite over networked block storage is the wrong backend for a busy Grafana. This moves it to a dedicated in-cluster **Postgres** — the durable fix.

## What
- **New `grafana-postgres` StatefulSet** — `postgres` (pinned `17-alpine` in `images:`), own **10Gi Longhorn** volume, `pg_isready` probes.
- **Service** `grafana-postgres:5432`.
- **SOPS-encrypted secret** `28-secret-grafana-postgres.sops.yaml` (KSOPS, same age recipient) with `POSTGRES_DB/USER/PASSWORD`.
- **Grafana rewired** via `GF_DATABASE_TYPE=postgres` + host/name/user/password (password from the secret) + `SSL_MODE=disable`. The `grafana-data` PVC stays mounted (Grafana still uses `/var/lib/grafana` for non-DB files).

Wiring follows repo conventions: STS/Service added to `kustomization.yaml` `resources:`, secret added to `ksops.yaml` `files:`, image pinned in the `images:` block.

## ⚠️ Fresh DB — action required after rollout
Grafana has **no supported SQLite→Postgres data copy**, so this starts a **fresh** DB:
- ✅ **Dashboards & datasources** survive — they're file-provisioned from ConfigMaps.
- ✅ **Admin user** bootstraps from the `grafana-admin` secret.
- ❌ **Service-account tokens are lost** — after rollout, the **GrafLens app token** and the **Grafana MCP token** must be recreated (I'll mint new ones via the admin API and hand them over).
- ❌ Non-admin users, UI-created alerts, annotations, stars, prefs — not carried over.

ArgoCD auto-sync (selfHeal) applies on merge: Postgres comes up, then Grafana rolls onto it (brief restart).

## Relationship to #561 (WAL)
Independent files/regions — no conflict. #561 is the quick interim relief for SQLite; this migration supersedes it (WAL is a no-op under Postgres). Merge #561 now if you want relief before this lands, or merge this and close #561.

Commit is unsigned (1Password signing was locked at authoring time).