### PR TITLE
pages: bump v0.2.3 -> v0.2.4 (restore MCP control plane)

### DIFF
--- a/apps/ai/pages/kustomization.yaml
+++ b/apps/ai/pages/kustomization.yaml
@@ -18,4 +18,4 @@ images:
   # Renovate bumps newTag when a new v* image is published.
   - name: registry.internal.white.fm/pages-mcp
     newName: ghcr.io/robertdwhite/pages-mcp
-    newTag: v0.2.3
+    newTag: v0.2.4


### PR DESCRIPTION
## Problem

`pages` MCP has been dead since v0.2.3 (2026-07-09) — `claude mcp list` shows `pages … ✘ Failed to connect`, and every `POST /mcp` returns **404** from the app (uvicorn logs confirm). All tools (`deploy_site`, `list_sites`, `get_site`, `delete_site`) are unreachable.

## Root cause

v0.2.3 added `white.fm` to `SERVE_HOST` (now `pages.internal.white.fm,white.fm`) to serve the public Authentik-gated site. The Gate's `_is_serve_host()` does a suffix match, so the control-plane host `pages-mcp.internal.white.fm` **also** matches `.white.fm` and gets treated as a content host:

```python
if _is_serve_host(host):  # never expose the control plane on a content host
    return PlainTextResponse("not found", status_code=404)
```

A bad token would have 401'd, so the 404-with-valid-token pointed straight at this gate.

## Fix

Already merged to `pages-mcp` `main` in 3f6fc81 (PR #2) — it exempts `MCP_HOST` from the content-host check. That fix was **never released**: no `v*` tag was cut from `main`, so CI never published a fixed semver image and the cluster stayed pinned to v0.2.3.

Cut tag `v0.2.4` on `main` (5ea3f9a); CI build succeeded and published `ghcr.io/robertdwhite/pages-mcp:v0.2.4` (`sha256:89ee7246…`, same digest as the verified `sha-5ea3f9a` build). This PR is just the pin bump.

## Verification

- `kustomize build apps/ai/pages` renders `ghcr.io/robertdwhite/pages-mcp:v0.2.4`
- Routing was already healthy (HTTPRoute Accepted/ResolvedRefs → `pages:8080`); `/healthz` 200 and static serving unaffected
- Post-merge check: `POST /mcp` should return **401** without a token (not 404)

## Note

Pod roll risks the node-15 Longhorn attach wedge — node-15 is currently `SchedulingDisabled`, so the roll should land elsewhere.