### PR TITLE
observability: migrate Grafana Postgres 17 → 18 (safe dump/restore)

### DIFF
--- a/observability/observability/28a-statefulset-grafana-postgres.yaml
+++ b/observability/observability/28a-statefulset-grafana-postgres.yaml
@@ -3,6 +3,13 @@ kind: StatefulSet
 metadata:
   name: grafana-postgres
   namespace: observability
+  annotations:
+    # Postgres 18 official image layout (breaking vs 17):
+    #   VOLUME  /var/lib/postgresql
+    #   PGDATA  /var/lib/postgresql/18/docker  (default; do not override)
+    # Major upgrades cannot reuse a 17 data directory in-place — see
+    # 28c-MIGRATE-postgres-17-to-18.md and scripts/migrate-grafana-postgres-17-to-18.sh.
+    white.fm/postgres-major: "18"
 spec:
   replicas: 1
   serviceName: grafana-postgres
@@ -24,9 +31,10 @@ spec:
           envFrom:
             - secretRef:
                 name: grafana-postgres
-          env:
-            - name: PGDATA
-              value: /var/lib/postgresql/data/pgdata
+          # Intentionally no PGDATA override. Official postgres:18+ defaults to
+          # /var/lib/postgresql/18/docker and expects the volume at
+          # /var/lib/postgresql (not .../data). Overriding PGDATA back to the
+          # pre-18 path defeats the image layout and breaks future major bumps.
           readinessProbe:
             exec:
               command: ["pg_isready", "-U", "grafana", "-d", "grafana"]
@@ -47,7 +55,8 @@ spec:
               memory: 512Mi
           volumeMounts:
             - name: data
-              mountPath: /var/lib/postgresql/data
+              # PG 18+ VOLUME target (was /var/lib/postgresql/data on ≤17).
+              mountPath: /var/lib/postgresql
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/observability/observability/28c-MIGRATE-postgres-17-to-18.md
+++ b/observability/observability/28c-MIGRATE-postgres-17-to-18.md
@@ -1,0 +1,106 @@
+# Grafana Postgres: 17 → 18 major upgrade
+
+**Do not** merge a bare image-tag bump (`17-alpine` → `18-alpine`) against an
+existing PVC. Postgres major versions are not on-disk compatible, and the
+official Docker image also changed its volume/`PGDATA` layout in 18.
+
+This directory is updated to the **Postgres 18 end state**. Cut over with the
+script (or the manual steps below). Supersedes Renovate PR #565.
+
+## What changed in manifests
+
+| Item | Postgres ≤17 (old) | Postgres 18 (new) |
+|------|--------------------|-------------------|
+| Image tag | `17-alpine` | `18-alpine` |
+| Volume mount | `/var/lib/postgresql/data` | `/var/lib/postgresql` |
+| `PGDATA` | `/var/lib/postgresql/data/pgdata` (explicit) | default `/var/lib/postgresql/18/docker` |
+| PVC name | `data-grafana-postgres-0` | same name (must be **deleted** and recreated empty) |
+
+Consumer is only Grafana (`GF_DATABASE_HOST=grafana-postgres:5432`). Dashboards
+and datasources are file-provisioned; users, SA tokens, annotations, and alert
+history live in this DB (~14 MB today) and **are preserved by dump/restore**.
+
+## Recommended: one script
+
+From a machine with `kubectl` context for this cluster and repo checkout:
+
+```bash
+# Dry-run: dump only, print next steps
+./observability/observability/scripts/migrate-grafana-postgres-17-to-18.sh dump
+
+# Full cutover (dump → wipe PVC → wait for PG18 → restore)
+# Run AFTER this PR is merged/synced (or pass --apply-local to kubectl-apply
+# the updated StatefulSet from your working tree before Argo catches up).
+./observability/observability/scripts/migrate-grafana-postgres-17-to-18.sh cutover
+```
+
+Expected downtime: a few minutes while Grafana cannot reach Postgres.
+
+## Manual steps (equivalent)
+
+### 1. Dump while still on 17
+
+```bash
+kubectl -n observability exec grafana-postgres-0 -- \
+  pg_dump -U grafana -d grafana -Fc -f /tmp/grafana.dump
+kubectl -n observability cp \
+  grafana-postgres-0:/tmp/grafana.dump ./grafana-postgres-17.dump
+```
+
+### 2. Merge / sync this PR
+
+ArgoCD (or `kubectl apply -k observability/observability`) rolls the StatefulSet
+to `postgres:18-alpine` with the new mount path. **If the old PVC is still
+attached**, the pod will CrashLoop (`database files are incompatible` or empty
+`PGDATA` path). That is expected until step 3.
+
+### 3. Recreate the data volume empty
+
+`volumeClaimTemplates` are immutable for an existing STS identity; we keep the
+claim name `data` and force a fresh volume:
+
+```bash
+kubectl -n observability delete pod grafana-postgres-0 --wait=false
+kubectl -n observability delete pvc data-grafana-postgres-0 --wait=true
+# StatefulSet recreates the pod + PVC; PG18 initializes a new cluster.
+kubectl -n observability rollout status statefulset/grafana-postgres --timeout=5m
+kubectl -n observability exec grafana-postgres-0 -- \
+  psql -U grafana -d grafana -c 'SHOW server_version;'
+# Expect 18.x
+```
+
+### 4. Restore
+
+```bash
+kubectl -n observability cp ./grafana-postgres-17.dump \
+  grafana-postgres-0:/tmp/grafana.dump
+kubectl -n observability exec grafana-postgres-0 -- \
+  pg_restore -U grafana -d grafana --clean --if-exists --no-owner \
+  /tmp/grafana.dump
+kubectl -n observability rollout restart deployment/grafana
+```
+
+### 5. Verify
+
+```bash
+kubectl -n observability exec grafana-postgres-0 -- \
+  psql -U grafana -d grafana -c \
+  "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';"
+# Hit https://grafana.white.fm — login / dashboards / SA tokens as before.
+```
+
+## Rollback
+
+1. Keep `grafana-postgres-17.dump` until verified.
+2. Revert this PR (image `17-alpine` + old mount/`PGDATA`).
+3. Delete `data-grafana-postgres-0` again, let STS recreate, restore the dump
+   with `postgres:17` (`pg_restore` from the same custom-format dump works on 17).
+
+If you still have the **pre-cutover** Longhorn volume snapshot/backup of
+`data-grafana-postgres-0`, you can reattach that volume only with the **17**
+image and the **old** mount/`PGDATA` — not with 18.
+
+## Out of scope
+
+Other Postgres instances in this repo (Authentik, Matrix, listmonk, etc.) use
+their own image pins and are not upgraded by this change.

--- a/observability/observability/kustomization.yaml
+++ b/observability/observability/kustomization.yaml
@@ -61,6 +61,8 @@ resources:
 
   # Grafana database (external Postgres StatefulSet, replaces SQLite)
   # 28-secret-grafana-postgres.sops.yaml is loaded via ksops.yaml generator
+  # Major upgrade runbook: 28c-MIGRATE-postgres-17-to-18.md
+  # scripts/migrate-grafana-postgres-17-to-18.sh
   - 28a-statefulset-grafana-postgres.yaml
   - 28b-svc-grafana-postgres.yaml
 
@@ -192,4 +194,4 @@ images:
     newTag: "1.2.1"
 
   - name: postgres
-    newTag: "17-alpine"
+    newTag: "18-alpine"

--- a/observability/observability/scripts/migrate-grafana-postgres-17-to-18.sh
+++ b/observability/observability/scripts/migrate-grafana-postgres-17-to-18.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Migrate observability/grafana-postgres from Postgres 17 → 18.
+#
+# Usage:
+#   ./migrate-grafana-postgres-17-to-18.sh dump
+#   ./migrate-grafana-postgres-17-to-18.sh cutover
+#   ./migrate-grafana-postgres-17-to-18.sh cutover --apply-local
+#   ./migrate-grafana-postgres-17-to-18.sh restore ./grafana-postgres-17.dump
+#
+# Requires: kubectl context for the whitehouse cluster.
+# See ../28c-MIGRATE-postgres-17-to-18.md
+set -euo pipefail
+
+NS=observability
+POD=grafana-postgres-0
+STS=grafana-postgres
+PVC=data-grafana-postgres-0
+PGUSER=grafana
+DB=grafana
+DUMP_LOCAL="${DUMP_LOCAL:-./grafana-postgres-17.dump}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OBS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+log() { printf '==> %s\n' "$*"; }
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+need_kubectl() {
+  command -v kubectl >/dev/null || die "kubectl not found"
+  kubectl -n "$NS" get sts "$STS" >/dev/null || die "StatefulSet ${NS}/${STS} not found"
+}
+
+server_version() {
+  kubectl -n "$NS" exec "$POD" -- psql -U "$PGUSER" -d "$DB" -Atc 'SHOW server_version;' 2>/dev/null || true
+}
+
+wait_pg_ready() {
+  local timeout="${1:-300}"
+  local i=0
+  log "Waiting for ${POD} Ready (timeout ${timeout}s)..."
+  while (( i < timeout )); do
+    if kubectl -n "$NS" get pod "$POD" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q True; then
+      if kubectl -n "$NS" exec "$POD" -- pg_isready -U "$PGUSER" -d "$DB" >/dev/null 2>&1; then
+        log "Postgres ready: $(server_version)"
+        return 0
+      fi
+    fi
+    sleep 3
+    i=$((i + 3))
+  done
+  die "Timed out waiting for ${POD}"
+}
+
+cmd_dump() {
+  need_kubectl
+  wait_pg_ready 60
+  local ver
+  ver="$(server_version)"
+  log "Dumping ${DB} from ${POD} (server ${ver}) → ${DUMP_LOCAL}"
+  kubectl -n "$NS" exec "$POD" -- \
+    pg_dump -U "$PGUSER" -d "$DB" -Fc -f /tmp/grafana.dump
+  kubectl -n "$NS" cp "${NS}/${POD}:/tmp/grafana.dump" "$DUMP_LOCAL"
+  kubectl -n "$NS" exec "$POD" -- rm -f /tmp/grafana.dump
+  ls -lh "$DUMP_LOCAL"
+  log "Dump complete."
+}
+
+apply_local_manifests() {
+  log "Applying local StatefulSet + image tag 18-alpine from ${OBS_DIR}"
+  kubectl apply -f "${OBS_DIR}/28a-statefulset-grafana-postgres.yaml"
+  kubectl -n "$NS" set image "sts/${STS}" postgres=postgres:18-alpine
+}
+
+cmd_wipe_and_recreate() {
+  need_kubectl
+  log "Deleting pod ${POD} and PVC ${PVC} so PG18 can init a fresh data dir"
+  kubectl -n "$NS" delete pod "$POD" --ignore-not-found=true --wait=false || true
+  for _ in $(seq 1 60); do
+    kubectl -n "$NS" get pod "$POD" >/dev/null 2>&1 || break
+    sleep 2
+  done
+  kubectl -n "$NS" delete pvc "$PVC" --wait=true --ignore-not-found=true
+  log "Waiting for STS to recreate pod + PVC..."
+  wait_pg_ready 300
+  local ver
+  ver="$(server_version)"
+  case "$ver" in
+    18.*) log "Confirmed Postgres ${ver}" ;;
+    *)
+      die "Expected Postgres 18.x after cutover, got '${ver}'. Is the 18 image rolled out?"
+      ;;
+  esac
+}
+
+cmd_restore() {
+  local dump_file="${1:-$DUMP_LOCAL}"
+  [[ -f "$dump_file" ]] || die "Dump file not found: ${dump_file}"
+  need_kubectl
+  wait_pg_ready 120
+  log "Copying dump into pod and restoring (pg_restore --clean --if-exists)"
+  kubectl -n "$NS" cp "$dump_file" "${NS}/${POD}:/tmp/grafana.dump"
+  # pg_restore can exit non-zero on benign notices; verify table count after.
+  kubectl -n "$NS" exec "$POD" -- \
+    pg_restore -U "$PGUSER" -d "$DB" --clean --if-exists --no-owner \
+    /tmp/grafana.dump || true
+  local tables
+  tables="$(kubectl -n "$NS" exec "$POD" -- \
+    psql -U "$PGUSER" -d "$DB" -Atc \
+    "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';")"
+  log "Public tables after restore: ${tables}"
+  (( tables > 10 )) || die "Restore looks incomplete (${tables} tables)"
+  kubectl -n "$NS" exec "$POD" -- rm -f /tmp/grafana.dump
+  log "Restarting Grafana to reconnect"
+  kubectl -n "$NS" rollout restart deployment/grafana
+  kubectl -n "$NS" rollout status deployment/grafana --timeout=3m
+  log "Restore complete."
+}
+
+cmd_cutover() {
+  local apply_local=0
+  for arg in "$@"; do
+    case "$arg" in
+      --apply-local) apply_local=1 ;;
+    esac
+  done
+
+  need_kubectl
+  log "Current server version: $(server_version || echo unknown)"
+
+  if [[ ! -f "$DUMP_LOCAL" ]]; then
+    cmd_dump
+  else
+    log "Reusing existing dump ${DUMP_LOCAL}"
+  fi
+
+  if (( apply_local )); then
+    apply_local_manifests
+  else
+    log "Assuming this PR is already merged/synced (postgres:18-alpine + new mount)."
+    log "If not, re-run with: $0 cutover --apply-local"
+  fi
+
+  cmd_wipe_and_recreate
+  cmd_restore "$DUMP_LOCAL"
+  log "Cutover finished. Keep ${DUMP_LOCAL} until you confirm Grafana looks good."
+}
+
+usage() {
+  sed -n '2,12p' "$0"
+}
+
+main() {
+  local cmd="${1:-}"
+  shift || true
+  case "$cmd" in
+    dump) cmd_dump ;;
+    restore) cmd_restore "${1:-$DUMP_LOCAL}" ;;
+    cutover) cmd_cutover "$@" ;;
+    wipe) cmd_wipe_and_recreate ;;
+    -h|--help|help|"") usage; exit 0 ;;
+    *) die "Unknown command: ${cmd}" ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Safe major upgrade for **Grafana's** Postgres (`observability/grafana-postgres`) from **17 → 18**, replacing the unsafe Renovate tag-only bump in #565.

Bare `17-alpine` → `18-alpine` will **CrashLoop** this StatefulSet:

1. Postgres major versions are not on-disk compatible.
2. Official `postgres:18` changed volume/`PGDATA` layout (`VOLUME` → `/var/lib/postgresql`, default `PGDATA` → `/var/lib/postgresql/18/docker`).

Live DB today: **17.10**, ~87 tables, ~14 MB — only consumer is Grafana 13 (dashboards/datasources are file-provisioned; users/tokens/annotations live here).

## Manifest changes

| File | Change |
|------|--------|
| `28a-statefulset-grafana-postgres.yaml` | Mount `/var/lib/postgresql`; remove pre-18 `PGDATA` override; document layout |
| `kustomization.yaml` | `postgres` image `18-alpine` + pointers to runbook/script |
| `28c-MIGRATE-postgres-17-to-18.md` | Full runbook + rollback |
| `scripts/migrate-grafana-postgres-17-to-18.sh` | `dump` / `cutover` / `restore` helper |

## Cutover (required — do not just merge and walk away)

```bash
# 1. Dump while still on 17 (can do before merge)
./observability/observability/scripts/migrate-grafana-postgres-17-to-18.sh dump

# 2. Merge this PR / wait for ArgoCD sync of the STS + image

# 3. Wipe PVC (new empty PG18 data dir) + restore + restart Grafana
./observability/observability/scripts/migrate-grafana-postgres-17-to-18.sh cutover
# or if Argo has not synced yet:
# ./observability/observability/scripts/migrate-grafana-postgres-17-to-18.sh cutover --apply-local
```

Expected downtime: a few minutes (Grafana cannot reach DB while PVC is recreated).

## Out of scope

Other Postgres pins in this repo (Authentik, Matrix, listmonk, …) are untouched.

## Supersedes

Closes / replaces the approach in **#565** (tag-only bump). Recommend closing #565 once this lands.

## Test plan

- [ ] `dump` succeeds against current `grafana-postgres-0` (17.x)
- [ ] After merge/sync: STS shows `postgres:18-alpine` and mount `/var/lib/postgresql`
- [ ] `cutover` brings up 18.x, restore table count > 10, Grafana deployment rolls healthy
- [ ] https://grafana.white.fm loads; auth / dashboards / existing SA tokens still work
- [ ] Keep `grafana-postgres-17.dump` until verified, then delete
