### PR TITLE
Unpin image digests on non-DB apps for Renovate

### DIFF
--- a/apps/ai/ai-stack/kustomization.yaml
+++ b/apps/ai/ai-stack/kustomization.yaml
@@ -35,7 +35,6 @@ commonLabels:
 images:
   - name: ollama/ollama
     newTag: "0.24.0"
-    digest: "sha256:a6149234667efc71d37766d61c1a16f24c33e4cd7a0bf4125c44a7e47e2419c4"
 
   - name: quay.io/go-skynet/local-ai
     newTag: "master-nvidia-l4t-arm64-cuda-13"

--- a/apps/ai/odysseus/kustomization.yaml
+++ b/apps/ai/odysseus/kustomization.yaml
@@ -23,4 +23,3 @@ images:
     digest: sha256:1e0b73a187a28757c572acba508c46f48c9e8b0acaf5c20e6d95cdedce1acdf6
   - name: busybox
     newTag: "1.37"
-    digest: sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028

--- a/apps/misc/gibt-es-gott/kustomization.yaml
+++ b/apps/misc/gibt-es-gott/kustomization.yaml
@@ -16,6 +16,6 @@ generators:
 images:
   - name: nginx
     newTag: "1.31-alpine"
-  # content-sync initContainer; pinned by digest (alpine/git:2.47.2)
+  # content-sync initContainer (alpine/git)
   - name: alpine/git
-    digest: sha256:697cb1c85aefc5724febaec2202a974e0d66f6abb6be91a9a86d0c8757af692a
+    newTag: "2.47.2"

--- a/apps/misc/gramps/kustomization.yaml
+++ b/apps/misc/gramps/kustomization.yaml
@@ -17,7 +17,6 @@ resources:
 images:
   - name: ghcr.io/gramps-project/grampsweb
     newTag: "26.6.1"
-    digest: "sha256:563d05ebb788fd42695ab4f5ec05efbfb86aa73d25901e6428fa9b0aab763551"
   - name: redis
     newTag: "7.4-alpine"
     digest: "sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99"

--- a/apps/misc/listmonk/kustomization.yaml
+++ b/apps/misc/listmonk/kustomization.yaml
@@ -18,7 +18,6 @@ generators:
 images:
   - name: listmonk/listmonk
     newTag: "v6.1.0"
-    digest: sha256:179d00d9553c371b6fe88c9b145095d651e275bdd66db46b2e0b79daff316b6f
   - name: postgres
     newTag: "17-alpine"
     digest: sha256:979c4379dd698aba0b890599a6104e082035f98ef31d9b9291ec22f2b13059ca

--- a/apps/misc/searxng/kustomization.yaml
+++ b/apps/misc/searxng/kustomization.yaml
@@ -17,7 +17,6 @@ generators:
 images:
   - name: docker.io/searxng/searxng
     newTag: "2026.6.14-b3e08f2a4"
-    digest: sha256:8f1e32b1013b1e74a9b769686edbca03ff5439395743725f3f18369b4841f709
   - name: docker.io/valkey/valkey
     newTag: "8.1.8-alpine"
     digest: sha256:77643d152547b446fc15cbafaff22004545663fcd40c6b28038ad283837baa75

--- a/apps/misc/wallabag/kustomization.yaml
+++ b/apps/misc/wallabag/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 
 images:
   - name: wallabag/wallabag
-    digest: sha256:4a527e027e0d59e87c14225ef11e005af3d4890374202ad319ce5e63dfc66709  # 2.6.14
+    newTag: "2.6.14"


### PR DESCRIPTION
## What

Removes `@sha256:` digest pins from **application / utility** images across the cluster so Renovate resumes proposing tag updates for them. **Datastore engines keep their digest pins** — a version jump there can break on-disk data / schema.

This matches the repo's own `disallow-mutable-image-tags` Kyverno policy, which requires digests only on DB engines and explicitly "does not require digests on non-DB images."

## Unpinned (now tag-tracked by Renovate)

| App | Image | Note |
|---|---|---|
| gramps | `ghcr.io/gramps-project/grampsweb` | dropped digest, kept `26.6.1` |
| wallabag | `wallabag/wallabag` | was digest-only → `newTag: 2.6.14` |
| listmonk | `listmonk/listmonk` | dropped digest, kept `v6.1.0` |
| searxng | `docker.io/searxng/searxng` | dropped digest, kept date tag |
| ai-stack | `ollama/ollama` | dropped digest, kept `0.24.0` |
| odysseus | `busybox` | dropped digest, kept `1.37` |
| gibt-es-gott | `alpine/git` | was digest-only → `newTag: 2.47.2` |

## Kept pinned (datastores — intentionally frozen)

Every `postgres`, `mysql`, `mariadb`, `redis`, `valkey`, `elasticsearch`, and `chromadb/chroma` retains its digest, plus the internal-registry `technitium-sidecar` (Renovate can't reach that registry anyway). Raw-manifest DB pins (MISP mariadb/redis, monica postgres, mastodon elasticsearch) were left untouched.

## Verified

`kustomize build` on the non-ksops overlays renders the target images as plain tags (`grampsweb:26.6.1`, `wallabag/wallabag:2.6.14`, `ollama/ollama:0.24.0`) while datastore images keep their digests. ksops overlays share identical `images:` syntax.