### PR TITLE
Fix node-14-pinned pods (homebridge, scrypted) blocked by kube-vip taint

### DIFF
--- a/apps/home/homebridge/homebridge-deployment.yaml
+++ b/apps/home/homebridge/homebridge-deployment.yaml
@@ -19,6 +19,11 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       nodeSelector:
         kubernetes.io/hostname: rke2-node-14
+      tolerations:
+        - key: kube-vip
+          operator: Equal
+          value: disabled
+          effect: NoSchedule
       initContainers:
         - name: seed-config
           image: busybox:1.37.0

--- a/apps/home/scrypted/scrypted-deployment.yaml
+++ b/apps/home/scrypted/scrypted-deployment.yaml
@@ -19,6 +19,11 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       nodeSelector:
         kubernetes.io/hostname: rke2-node-14
+      tolerations:
+        - key: kube-vip
+          operator: Equal
+          value: disabled
+          effect: NoSchedule
       containers:
         - name: scrypted
           image: koush/scrypted


### PR DESCRIPTION
## What

homebridge and scrypted are pinned to `rke2-node-14` via `nodeSelector` (they need hardware on that host), but node 14 carries a `kube-vip=disabled:NoSchedule` taint that they don't tolerate — so they've been stuck `Pending` (homebridge for 30+ days). Adds the matching toleration to both so they can schedule on node 14.

## Change

```yaml
tolerations:
  - key: kube-vip
    operator: Equal
    value: disabled
    effect: NoSchedule
```

Surgical (only these two pods gain the toleration); node 14's taint and kube-vip behavior are untouched.