### PR TITLE
glance: add icons to all bookmarks missing them

### DIFF
--- a/apps/home/glance/config/glance.yml
+++ b/apps/home/glance/config/glance.yml
@@ -412,8 +412,10 @@ pages:
           icon: di:tautulli
         - title: HDHomeRun
           url: http://10.100.7.30
+          icon: di:hdhomerun
         - title: Dispatcharr
           url: https://tv.internal.white.fm
+          icon: di:dispatcharr
         - title: Ombi
           url: https://ombi.internal.white.fm
           icon: di:ombi
@@ -453,6 +455,7 @@ pages:
           icon: di:calibre-web
         - title: Shelfmark
           url: https://shelfmark.internal.white.fm
+          icon: sh:shelfmark
         - title: Wallabag
           url: https://wallabag.internal.white.fm
           icon: di:wallabag
@@ -477,6 +480,7 @@ pages:
           icon: di:freshrss
         - title: ZNC
           url: https://znc.white.fm
+          icon: mdi:chat-processing
       - title: AI & Research
         links:
         - title: Open WebUI
@@ -487,6 +491,7 @@ pages:
           icon: di:ollama
         - title: SDR Research
           url: https://sdr.internal.white.fm
+          icon: mdi:antenna
         - title: RStudio
           url: https://rstudio.white.fm
           icon: di:rstudio
@@ -495,36 +500,50 @@ pages:
           icon: di:searxng
         - title: Odysseus
           url: https://odysseus.internal.white.fm
+          icon: mdi:brain
         - title: Hermes
           url: https://hermes.internal.white.fm
+          icon: mdi:robot
       - title: Intelligence & Security
         links:
         - title: MISP
           url: https://intel.internal.white.fm
+          icon: mdi:shield-search
         - title: IntelOwl
           url: https://intelowl.internal.white.fm
+          icon: sh:intelowl
         - title: OpenCTI
           url: https://opencti.internal.white.fm
+          icon: mdi:radar
         - title: Raven
           url: https://raven.internal.white.fm
+          icon: mdi:bird
         - title: Yeti
           url: https://yeti.internal.white.fm
+          icon: mdi:paw
         - title: OpenClaw
           url: https://openclaw.internal.white.fm
+          icon: sh:openclaw
       - title: Radio & Tracking
         links:
         - title: ADS-B
           url: https://adsb.internal.w3rdw.radio
+          icon: mdi:airplane-marker
         - title: FlightRadar24
           url: https://fr24.internal.w3rdw.radio
+          icon: di:flightradar24
         - title: Jetlog
           url: https://jetlog.internal.white.fm
+          icon: mdi:airplane-takeoff
         - title: Keeptrack
           url: https://satellites.white.fm
+          icon: mdi:satellite-variant
         - title: Ground Station
           url: https://sat.internal.white.fm
+          icon: mdi:satellite-uplink
         - title: OpenHamClock
           url: https://hamclock.internal.w3rdw.radio
+          icon: mdi:clock-outline
       - title: Smart Home
         links:
         - title: Home Assistant
@@ -540,28 +559,40 @@ pages:
         links:
         - title: Weather
           url: https://weather.internal.white.fm
+          icon: mdi:weather-partly-cloudy
         - title: Astronomy
           url: https://astronomy.internal.white.fm
+          icon: mdi:telescope
         - title: Politics
           url: https://politics.internal.white.fm
+          icon: mdi:vote
         - title: World Monitor
           url: https://worldmonitor.internal.white.fm
+          icon: mdi:earth
         - title: Hub
           url: https://hub.internal.white.fm
+          icon: mdi:hub
         - title: Backoffice
           url: https://backoffice.internal.white.fm
+          icon: mdi:briefcase
         - title: Homeschool
           url: https://homeschool.internal.white.fm
+          icon: mdi:school
         - title: MySpeed
           url: https://speed.internal.white.fm
+          icon: di:myspeed
         - title: CyberChef
           url: https://cyberchef.internal.white.fm
+          icon: di:cyberchef
         - title: Congress Trades
           url: https://congress.internal.white.fm
+          icon: mdi:finance
         - title: App Store Reviews
           url: https://appstore.internal.white.fm
+          icon: mdi:star-box-multiple
         - title: Badges
           url: https://badges.internal.white.fm
+          icon: mdi:shield-star
         - title: Listmonk
           url: https://listmonk.internal.white.fm
           icon: di:listmonk
@@ -576,8 +607,10 @@ pages:
           icon: di:monica
         - title: Ancestry (Gramps)
           url: https://ancestry.internal.white.fm
+          icon: di:gramps
         - title: EveryDocs
           url: https://everydocs.internal.white.fm
+          icon: mdi:file-document-multiple
         - title: Fleet
           url: https://fleet.internal.white.fm
           icon: di:fleet
@@ -589,10 +622,13 @@ pages:
           icon: di:nitter
         - title: Nodebyte
           url: https://nodebyte.internal.white.fm
+          icon: mdi:server-network
         - title: Card Optimizer
           url: https://cards.internal.white.fm
+          icon: mdi:credit-card-multiple
         - title: Gibt es Gott?
           url: https://gibt-es-gott.internal.white.fm
+          icon: mdi:cross
         - title: Homepage
           url: https://homepage.internal.white.fm
           icon: di:homepage
@@ -600,40 +636,57 @@ pages:
         links:
         - title: Index
           url: https://pages.internal.white.fm
+          icon: mdi:folder-multiple
         - title: White Ancestry
           url: https://white-ancestry.pages.internal.white.fm
+          icon: mdi:family-tree
         - title: Job Pipeline Tracker
           url: https://jobs.pages.internal.white.fm
+          icon: mdi:briefcase-search
         - title: MSP Outreach Dashboard
           url: https://msp-outreach.pages.internal.white.fm
+          icon: mdi:bullhorn
         - title: Robinhood $100 Challenge
           url: https://robinhood.pages.internal.white.fm
+          icon: di:robinhood
         - title: Wallace & White Client Map
           url: https://ww-client-map.pages.internal.white.fm
+          icon: mdi:map-marker-multiple
       - title: Book Trainers
         links:
         - title: Book Trainers Hub
           url: https://book-trainers.pages.internal.white.fm
+          icon: mdi:bookshelf
         - title: VOSS Negotiation Trainer
           url: https://voss-trainer.pages.internal.white.fm
+          icon: mdi:handshake
         - title: DARK Psychology Trainer
           url: https://dark-psychology-trainer.pages.internal.white.fm
+          icon: mdi:drama-masks
         - title: 48 Laws of Power Trainer
           url: https://48-laws-of-power.pages.internal.white.fm
+          icon: mdi:crown
         - title: 7 Rules of Power Trainer
           url: https://7-rules-of-power.pages.internal.white.fm
+          icon: mdi:chess-king
         - title: Dare to Lead Trainer
           url: https://dare-to-lead.pages.internal.white.fm
+          icon: mdi:account-group
         - title: The Effective Executive Trainer
           url: https://effective-executive.pages.internal.white.fm
+          icon: mdi:briefcase-check
         - title: Financial Intelligence Trainer
           url: https://financial-intelligence.pages.internal.white.fm
+          icon: mdi:cash-multiple
         - title: The First 90 Days Trainer
           url: https://first-90-days.pages.internal.white.fm
+          icon: mdi:calendar-check
         - title: The Lifegiving Parent Trainer
           url: https://lifegiving-parent.pages.internal.white.fm
+          icon: mdi:human-male-child
         - title: Selling to the C-Suite Trainer
           url: https://selling-to-c-suite.pages.internal.white.fm
+          icon: mdi:presentation
       - title: Downloads
         links:
         - title: Prowlarr
@@ -644,6 +697,7 @@ pages:
           icon: di:sabnzbd
         - title: YT-DLP
           url: https://ytdl.internal.white.fm
+          icon: di:yt-dlp
         - title: qBittorrent
           url: https://qbit.internal.white.fm
           icon: di:qbittorrent
@@ -660,6 +714,7 @@ pages:
           icon: si:x
         - title: Nitter
           url: https://nitter.white.fm
+          icon: di:nitter
         - title: Scholar
           url: https://scholar.white.fm
           icon: si:googlescholar
@@ -670,8 +725,10 @@ pages:
         links:
         - title: WhiteMatter
           url: https://whitematter.tech
+          icon: mdi:post-outline
         - title: W3RDW Radio
           url: https://w3rdw.radio
+          icon: mdi:radio-tower
       - title: Developer
         links:
         - title: GitHub
@@ -686,16 +743,22 @@ pages:
         links:
         - title: Chase
           url: https://www.chase.com
+          icon: si:chase
         - title: Amex
           url: https://www.amex.com
+          icon: si:americanexpress
         - title: Capital One
           url: https://myaccounts.capitalone.com
+          icon: sh:capital-one-light
         - title: Citi
           url: https://citi.com
+          icon: sh:citibank-light
         - title: PNC
           url: https://pnc.com
+          icon: mdi:bank
         - title: US Bank
           url: https://usbank.com
+          icon: sh:u-s-bank-light
   - size: small
     widgets:
     - type: custom-api


### PR DESCRIPTION
63 of the 116 bookmarks in the Glance config had no `icon:` set. This adds one to every remaining bookmark.

## Approach

- **Brand icons** (`di:` / `sh:` / `si:`) wherever a real logo exists — HDHomeRun, Dispatcharr, Shelfmark, IntelOwl, OpenClaw, FlightRadar24, MySpeed, CyberChef, Gramps, Robinhood, YT-DLP, Nitter, and the bank logos.
- **`mdi:` semantic icons** for the in-house apps that have no logo anywhere (Odysseus, Hermes, Nodebyte, Backoffice, Homeschool, the book trainers, the pages sites, etc.).

Two brand-name collisions were deliberately rejected: `si:hermes` is the fashion house, not the Matrix/Telegram agent, and `si:yeti` is the cooler brand, not the threat-intel platform. Both use `mdi:` instead.

Glance renders on the dark default theme, so `si:`/`mdi:` (which auto-invert) are safe as-is, and the bank logos use selfhst's `-light` variants that are built for dark backgrounds.

## Verification

- All 63 icon URLs return HTTP 200 from jsdelivr — no broken images.
- `config:validate` against glance v0.8.5 exits 0 (same as before the change).
- Ran v0.8.5 locally with the new config: all 63 icons appear in the served HTML and render legibly on the dark theme.
- Diff is 63 pure insertions, 0 deletions; parsed YAML is identical apart from the added `icon` keys.