### PR TITLE
fix(media): recover vpn-proxy automatically instead of leaving it wedged

### DIFF
--- a/apps/media/media/01-proxy.sops.yaml
+++ b/apps/media/media/01-proxy.sops.yaml
@@ -1,154 +1,170 @@
-apiVersion: ENC[AES256_GCM,data:+eMCyvUU0Q==,iv:aMWgNGoH16OU/2McLNlnINS4zljg1iRKGZEsD0nkLg0=,tag:eSEJVvjXZxFPLf8G3KET5g==,type:str]
-kind: ENC[AES256_GCM,data:KOsMqEqekhPIXA==,iv:aQ33u6pXn81WH/mAj2vOh3uWiD1nz333aiSS+8YQ+eI=,tag:RGzCDQtVXZlTHKpZWtWH2g==,type:str]
+apiVersion: ENC[AES256_GCM,data:jfK20A0s8A==,iv:/EhR2RqUXlUsLSjQ2ciTDSNCVH3DP7jfsyGy8NWhLGY=,tag:U7XtlVdrGXFnhq2wMkuVQQ==,type:str]
+kind: ENC[AES256_GCM,data:X4bSOOG12Q7EIw==,iv:G9Q+lPpo56iwM/zeulQL3wwBAYeajIs09kat7Of+6nk=,tag:Tvtk3bYuosGwD9kiEykCww==,type:str]
 metadata:
     labels:
-        app: ENC[AES256_GCM,data:FiUnEy2PohLt,iv:2BG/agYcH+sOHGboFHrJRqrea+37edcHOR6UtSbcPi0=,tag:AOXGG7QZnDVSSk+6djzLcg==,type:str]
-    name: ENC[AES256_GCM,data:G9oRk4P7ALkI,iv:YyO2tNWW7yj6ylEGxLNMTgY/1kN5KWopDcrATdmdEYc=,tag:YO85L7CE+bNmurjabiEQDw==,type:str]
-    namespace: ENC[AES256_GCM,data:2Q2V31U=,iv:z8Gjgx6UOkKDE8UVYy8SynbAVwVK2HoyWX/TBOzG7pY=,tag:4JlUpb76bn6G4j5YfeTXRw==,type:str]
+        app: ENC[AES256_GCM,data:H2hlWhYBrgHh,iv:m2baEFWf8IuDatwioaXVzNrl3howalCIIFd/DgBGegw=,tag:kcV9lL2su1LHWl1+qF1F+A==,type:str]
+    name: ENC[AES256_GCM,data:L0mPGiQTIODp,iv:tkAJBO5Lpe+LYkmCBOBxw3UWaICt1JhlJR/JNSKKfKk=,tag:FqNSdV8ZuoMO47dFJY1EBQ==,type:str]
+    namespace: ENC[AES256_GCM,data:Y1eOkEk=,iv:MLd3ORi5x90deObQp2lilHdidBQkjHiYAV1afSUgO+s=,tag:70SmAamj11cBcLIvzV0mlw==,type:str]
 spec:
-    replicas: ENC[AES256_GCM,data:qQ==,iv:Kh8dqvkBn7FeI9GI/2tQ6jcdENLTYBiJj5AiiEWHFgA=,tag:2iSRDvXDNzYFPkMPMaYpIQ==,type:int]
+    replicas: ENC[AES256_GCM,data:9A==,iv:Q9rWt6gLRXPoa8wPqDu82Pcu/66m8VsBBhKoH+gtwHg=,tag:dTnhAMPOOUdcVhIfZ+tb/g==,type:int]
     selector:
         matchLabels:
-            app: ENC[AES256_GCM,data:yEowzLedL+ZK,iv:75uWVsAyliMr8cO755BZaiqfn73aAXLZJ0fQ2biBUzU=,tag:boNxDdNRDWbm/UV2a9LPRA==,type:str]
+            app: ENC[AES256_GCM,data:XBLZoFZBFxFb,iv:cSsF1kOvjO/JTZak4q2Sy+1i97phtSYsOeBVKfUDuBE=,tag:XlFtMvfSIf8LA2WKibAU7A==,type:str]
     template:
         metadata:
             labels:
-                app: ENC[AES256_GCM,data:sNO36R2Hy+ST,iv:mFZ0oiFKFoGPzGAfZoApaLkgqREvd8mHTTlEBC8/qeA=,tag:4xKfYfkdL9XieHyxfz9Yzg==,type:str]
+                app: ENC[AES256_GCM,data:9077qLEQfFLo,iv:jGyu5NiEtS00dQVDBmo0t5T6hNFIyem7iQf1R0+n6EI=,tag:UHluLREH7SPACqECs7zEYQ==,type:str]
         spec:
             affinity:
                 nodeAffinity:
                     requiredDuringSchedulingIgnoredDuringExecution:
                         nodeSelectorTerms:
                             - matchExpressions:
-                                - key: ENC[AES256_GCM,data:hkAETZL4tmT5Llc88jCSoT1PbBgLDQ==,iv:qh4gD0UORaAPmU/3948O/miq6oB8Us5NVwHohLmeieg=,tag:E9cg8uFEny91VweaoxPDSw==,type:str]
-                                  operator: ENC[AES256_GCM,data:VwRMdLI=,iv:zUCboWqYGPa62mkNn+voWsQ4n6qxRLS90l9gwgrvmHU=,tag:SLo5cjMf4hnTbTma2wbR2g==,type:str]
+                                - key: ENC[AES256_GCM,data:ttjFcId8UBA2PaAmZ7q4Dh0uohG9Lw==,iv:/53GLZ1seKDdYBm/68aMYy0LODkO1aQwkurhfobAiBg=,tag:cm93yJpTf4QwhM5aYSGtyQ==,type:str]
+                                  operator: ENC[AES256_GCM,data:XVBT+dc=,iv:qBN5M2rsO66jaQrZlyhnCTVCF2Z5uRXotpVNqtPKNI0=,tag:CigNhH1ujbP+T5BZ284PWA==,type:str]
                                   values:
-                                    - ENC[AES256_GCM,data:jCpCyaO5ExpVWzxc,iv:V0CBob8oRU+TvA5Rbu0NWl83HMgpXFIPpNkV7t3dBZU=,tag:lM07LntcT0XriEl4qqW9fw==,type:str]
+                                    - ENC[AES256_GCM,data:K+VCxjeg8AV6gK7K,iv:DYGTN79kDGBPVeKj1LfqWyDYxnOnf4+ckVAOPHq9NoM=,tag:buJdb5feBo7lvPDeWHuVKw==,type:str]
             containers:
                 - env:
-                    - name: ENC[AES256_GCM,data:dp+FI9FjuCkdqT5j37rezCGtGsg=,iv:l6kQDuCQIGyw49Yh8q3rUqV5He58rPUQwFLvqZPF3hQ=,tag:QiKjsHSjN2jQm6RNsSyV9A==,type:str]
-                      value: ENC[AES256_GCM,data:FVKgzI3jGn6uAhni8rhRMLXn3DplnU8=,iv:EPxKiR3mEyHymUsNzlfC3Of4JmuJrQMXC2va1Fql6KE=,tag:6i5H/99IUDNbODUxoTi92w==,type:str]
-                    - name: ENC[AES256_GCM,data:Sjsx9Q0WkoA=,iv:SIt3LbKSyTRJ9irTKY1TKmI0OsW+eubpxCDx/a5k9F0=,tag:GDpzSyyPy0xQNwkOkAdVxg==,type:str]
-                      value: ENC[AES256_GCM,data:wZfOF3VoEA==,iv:5VMJq/C27UJZp9LLF2HKY7EPt+V1eREXJc80XSJqs7Q=,tag:UxjZXEWk4Gy2pHSgt5U08g==,type:str]
-                    - name: ENC[AES256_GCM,data:mMvY8lRKMDBtWLesI7o=,iv:G4GT8ypuWjDwD1YmZ8fxJ0j93ViQIXLhcac3HQJfD20=,tag:WjTpyzW2SnkSYhLeWhhAkg==,type:str]
-                      value: ENC[AES256_GCM,data:uSF197MlkTTiF2jeLP2fAVLT4/1R3m3epWEIqnu+b+FIVGFQSptGQomTkZtGVgZU3anoYibMxZsYNTMEv1Oyd29kpIVMHXfY+RxHOyncGHBBHrUA6TLs33UrXowjYFSLVGVPepbDexKHrZlxONqvTmFUHKoYDF81i4Ke,iv:OyCAxM2nsA73o0HNBHcxDzTx9WKdEJgzrKAGFKw+RrY=,tag:BtEzlLuuoorjJa+PjatmPg==,type:str]
-                    - name: ENC[AES256_GCM,data:1IDqFbnHSi7N9RLr0d8=,iv:Z86zXZx74wn4+rz3B/u5Wc1fJuCRkTq2SmgVPMAlTCg=,tag:4mLHQs2tKTEvcMBcEq7wUg==,type:str]
-                      value: ENC[AES256_GCM,data:/h+B,iv:xz7G1P0IB2AjyQEPoQc5Mx89p5Q8CarGn/xcVvrVtbQ=,tag:Oibi0mAdFRKsCWmtwWO+Eg==,type:str]
-                    - name: ENC[AES256_GCM,data:VANwMisAn1XZ,iv:+qPGLSLlsxkCHLshQAett1VWlG2g0KMV4XgMkQ7T8+M=,tag:o5bjlDnQAB1qW+TGJKayug==,type:str]
-                      value: ENC[AES256_GCM,data:mx8=,iv:Qw051AafElC9IjkzzuW01Vprf7I6XRu0xdaQaQBYIfg=,tag:ewKIgXyvAaUuCB9lhKf0Aw==,type:str]
-                    - name: ENC[AES256_GCM,data:WJquItgHzgfF0wXuyQ==,iv:ZKmU8D1rNuWYOBHpPNsIXK90X6bJPQUxhf6eCBp5GoQ=,tag:s8+G/3LTYPu3bgkoOVMhhg==,type:str]
-                      value: ENC[AES256_GCM,data:NITE,iv:xpwy3L6rfDJHpyEJE+/V6vZyeWZKpAizbPDQZ5sTaa4=,tag:ecv4VW/t5YFtRm8sjU9SQg==,type:str]
-                    - name: ENC[AES256_GCM,data:TSeJ2lZdhwDdwoM=,iv:17RjHGYs+slYIjLNqXf7vtnu8groSdhWms2OkAhWSzg=,tag:PVm+VdCvLAr8vBa1OyeVQQ==,type:str]
-                      value: ENC[AES256_GCM,data:NITE,iv:xpwy3L6rfDJHpyEJE+/V6vZyeWZKpAizbPDQZ5sTaa4=,tag:ecv4VW/t5YFtRm8sjU9SQg==,type:str]
-                    - name: ENC[AES256_GCM,data:CQAxyfLnlKXJ3qgS9A53I+Zypvk=,iv:h/XxKUjZFrUwTKql2Dkg934E2CsykuDwypdbHLBchlc=,tag:4TvTWNmhgSLmnVjp/eVA7A==,type:str]
-                      value: ENC[AES256_GCM,data:Eil/9OLXKJZGVnGGo08=,iv:ryxLZ1RrWNQRfTqqbFBCQC+vw56U8rJHVEYdb9W6BXA=,tag:3/oRZMJFqY4j0IwiaysatQ==,type:str]
-                    - name: ENC[AES256_GCM,data:DpXoty5r2MV05+jWjWWpKpZCAiNHfxVtyQ==,iv:xalmFV6HKic/8RL12A5K0fH9Cj2SJ67o2SBg1It3g6I=,tag:ZmzSggYShm+RpXlY/8Ld0g==,type:str]
-                      value: ENC[AES256_GCM,data:WPZWs8G2R69yZ7KDIUvv26LOvvTkZbiumJ890UCXJbvX/zjZIzrB,iv:xWUjOQO5uNVoOHcSRExvjNpONRa6pY49zQRtDObij4w=,tag:IaS85QJnIQQQsVM0pB80vA==,type:str]
-                    - name: ENC[AES256_GCM,data:2qW4rucEyQAczeXK,iv:hKF7dNim0Pmuqo0DUmdjIWfkvRU2M8BTtX/yC44h7hg=,tag:Ra7BbgYD9oMwleL3ZdIkHw==,type:str]
+                    - name: ENC[AES256_GCM,data:nzy6Teq5xlhbd/2YIXr0A87vzpQ=,iv:YMmvuPBYKzDHAJtN+sia27hoSEVhS73N9oWFVqOsOT4=,tag:jeRnPdUBNK3MAqfXxRs6vw==,type:str]
+                      value: ENC[AES256_GCM,data:c8Veec4PafycqSUmfWeQZxiOcArxvmo=,iv:BN4DdNBLLKo6x4IuSDTMsY5NLzAC1bH7hWWpgqyGMhQ=,tag:yc8Gwo5ODyYn7QRKoIwymg==,type:str]
+                    - name: ENC[AES256_GCM,data:yWnyiHpSEu4=,iv:UqOn2LT7tE3o3Hby8JzP3jQpjyBf/m16E5UxvkQOyRw=,tag:OBxOIxCPZjKH3e3ZYHzV3g==,type:str]
+                      value: ENC[AES256_GCM,data:17yp7iih6Q==,iv:3xIoqvoJstgxRbTCXmk779Yyz/DCd6WtBlAXRxaRHOo=,tag:IgWMFBgi0jPkSeuIt9yZfA==,type:str]
+                    - name: ENC[AES256_GCM,data:Sw5e/GpHouMh2yuVp8A=,iv:AKBVSZQkUhKcM6eETWSHqr+fhXbh5hZSqRevdLWdNQk=,tag:wJjtItdk8rSt+ZpKTCs6LA==,type:str]
+                      value: ENC[AES256_GCM,data:6/QRj/j6bH1fUCwXfLMQqRsHX9w71r8dY2RJ0F74jEWOF42avtKe3e0sEAhTTfzssGiAMo31EF4r0LAG0intyeJPCcVrouUSNbi3XWHRCLFf8Qgksy45vatD/HInfPlxvOyT7uPwPXrQgdIyZ9j93X4kuj/PZysimaoV,iv:QhVEGGOpxDDAT5gyRGSy9rx8Os3IJEZ7R4K/GAd+HlM=,tag:+vriAacpRsD1hmCPjAkVNQ==,type:str]
+                    - name: ENC[AES256_GCM,data:EQ7vcgmoY6RGW9LyiDc=,iv:kq9URM/FCZZlGMEExxOQ2p+M8cgwihYeXPKPDRJAw/0=,tag:tqKJNw34CKL1gFCugJe+Hg==,type:str]
+                      value: ENC[AES256_GCM,data:4HYp,iv:VlOXBr8VS0ueNKnn7N16RO8LbhrnswNBSGqJfhKOqoo=,tag:Wofvt9M595HDDU0mCPtNlw==,type:str]
+                    - name: ENC[AES256_GCM,data:pTSqmJzq3irR,iv:GxGWhnNUg9kZ9z/jPl9xHt7UET9wwNIRG0/oRfGSJMo=,tag:+kYZP5Qcq1Co8YC18IaqSg==,type:str]
+                      value: ENC[AES256_GCM,data:eNs=,iv:/sWSlRIQ3dWv9D1jHahKAXQtW2AGbeY7xR1kFBjHI3w=,tag:RATNBgp5vGgnLdfKPe4Z9A==,type:str]
+                    - name: ENC[AES256_GCM,data:CHWY6KgAQjOGFcuAcQ==,iv:aElxGz8pQAaqi+WG6ZX27h1HWsZwtBnXsrE1MUUM0gM=,tag:yqJfKF13NGHUipY1MDdF2g==,type:str]
+                      value: ENC[AES256_GCM,data:IqOi,iv:ZlvRXmHULOPXbVTjDYDll9DWvdJUYBNro4CyqdsHxzw=,tag:z7FXQCyZOE32fj4QPUNvFA==,type:str]
+                    - name: ENC[AES256_GCM,data:5cosKYRj17izOXY=,iv:4qP3OmomsWOWK0o7zxlMg+owprIhwsDqckxUCDmhfDA=,tag:ep3coOgin2Ls2vhhWfoe0g==,type:str]
+                      value: ENC[AES256_GCM,data:X/1J,iv:WJ0r8uuM6scs5gybLTFUI4iPBz2cnqfN7cwMH4mJ/tk=,tag:luKa2OoxcM1ONf3d+UYHqA==,type:str]
+                    - ENC[AES256_GCM,data:29iegDA4gfEE4iKkVcmStHfaEnBhIL5I/+rvr6e8MEDRBr76awkrc1b1HiYZ419Bhw5SZorgnr1G/gshSKb2VlZz,iv:XO2dz/Ta6ynzRUvSEDMq+7wXjDlIacaCP10bS4zWz3o=,tag:aKHE3TRsLt7L3QJ7F42dKQ==,type:comment]
+                    - ENC[AES256_GCM,data:yUKI8Tel1FrwU2Gjun6YxaMRiEs4sp1JaQJXgi0bzdKcP9Rd3KaGpgyRbRT2rEX+uQY4QGFXm6TR4OJx8KdpIuvSbQ==,iv:1elM8FZl7yqk85VLKNt4BjvZVNLW4hGlq5S/Jur6MmE=,tag:1EMEaNYvD0NOm8V4qKvL4w==,type:comment]
+                    - ENC[AES256_GCM,data:VG8xtKutV0DTQ2D6aCo/oJBPeKIl8zaHzH9euzceKyD2tH+vyDRmVrIu+fNywqr8HTZRrBghRQOWfQxyoCI5G/Guik0=,iv:jT682PWScGKPLv1yNMN7EdBYvLPRGcAQVGRvSwF6y5o=,tag:5TGI5h7SZSF+/ZxqfulC8Q==,type:comment]
+                    - ENC[AES256_GCM,data:iIrvPw2aHZG5ApnDuFhBYmbb8fD8kMzdGAcK/t/0JLSAM7RrpPPDOSc1uWfmv7oDYplTdxyqopi4cE01oGVp5o/P/F0=,iv:uud9N7Clc6SsDPCPKpntnS/UnvcE/GPArYMlbbOQAY8=,tag:ri8k/8BVGlf4G5n08PshUQ==,type:comment]
+                    - name: ENC[AES256_GCM,data:Azr6W21skZ02F4eq6VaG,iv:xkznrNjj1mQdQ31Bc52XJlnfuC/lzi7JFMjy5buqRVc=,tag:p+Z9YeCVKraxcBUjiidrKg==,type:str]
+                      value: ENC[AES256_GCM,data:Vj/i,iv:jr2sxRDyHhGPqPjaE9FcrVp91+IpEOUfD4c4z6rUUbo=,tag:N8zt1vJkJNQVBgLdCS6LNA==,type:str]
+                    - name: ENC[AES256_GCM,data:PlrFuzQojx2W,iv:ci4dvvPDYsXmrnyBs2IQ+aKe+6kGMfFYJ3NGuvbGtDo=,tag:Flm+G/ZlykxyLpkeLU8W1A==,type:str]
+                      value: ENC[AES256_GCM,data:cAKG,iv:dpRKY3QqRWNLK9qaE9eOcNt6KaB9nQ/FiA1fADEFFeo=,tag:tAhpPoWkc4dnfyfKuIbETA==,type:str]
+                    - name: ENC[AES256_GCM,data:HryUzkAbF3PBiEeZxcPpcWOh,iv:Kr57DvLzYgMRwPVem9cjLv29bMPCM0kaehxNNJFuVNY=,tag:I/0kyz63RzTUOVYSQzPjXw==,type:str]
+                      value: ENC[AES256_GCM,data:Ep2O,iv:11qD1hxRs3GyErchM7J7nMXz/QJZ9fZ64ox1QuPxEtQ=,tag:64MwfAYIFHuvKN4McOj4Ug==,type:str]
+                    - name: ENC[AES256_GCM,data:JveW8l2LUEPzi5NR70Yq/J8=,iv:miNGrIniasyr+w0mV1OgNgrWY54G8nZFm6VUgQWc1rs=,tag:lwPDe0YI1LDSTCpTCMbGQA==,type:str]
+                      value: ENC[AES256_GCM,data:cQ==,iv:1Ey6ne5A6lNK/OQuoMH3+DUjVIGghZTvBFShFgHNKSU=,tag:LaeH2Tq1369Qc2ZFA0aLjQ==,type:str]
+                    - name: ENC[AES256_GCM,data:N6dapzrr4HognupRS3dG9tv7EDM=,iv:S6LF9Z33/zXTyDwqivfpx3RzGRJmOvqfgo7Fv16qL54=,tag:9aUPxOHOqUlmgHhACg1ovA==,type:str]
+                      value: ENC[AES256_GCM,data:jv8Y8X9kpngAxavGedY=,iv:VQK/4YVEZyD5sjfg80YrhaYdoElMPFDdLvD9qcz3e9c=,tag:yWeStA6fNKClwIe7lMH2/g==,type:str]
+                    - name: ENC[AES256_GCM,data:2EMTpYo1vBcnlq6STSqoutlfPYTPo0iivg==,iv:mpFC+DgcuS+zL5cTU3l5XGq9C/m0AL4uymkvFMmjJLY=,tag:+E0NL59QQ8T+kcTbxQnauA==,type:str]
+                      value: ENC[AES256_GCM,data:/xxU1NnuEc+cfVHccMpLJxfhJ8MWkRXZOjRT5IatwA30v1MDDZQa,iv:KqFLeNrhm50gt9RoDaCXGy2K30lGBPZdLyS1HBkJ3HU=,tag:L/Z2+UU0YkH81iyeeZRGzQ==,type:str]
+                    - name: ENC[AES256_GCM,data:a+d0OaZ6ta59uqck,iv:qq+UtLakThp8d4S9932YHkp+ITY+DoCi1ATYEoFiG7E=,tag:Dsv7BzphtinYtdMENG86vA==,type:str]
                       valueFrom:
                         secretKeyRef:
-                            key: ENC[AES256_GCM,data:y3KCyhYsfhE=,iv:e2hWDfaAH9tVXU+DK7zh8qAMSc5vPeSD6MKTBV//VOY=,tag:mo48ZLlf6QIXMVDMbR0dFQ==,type:str]
-                            name: ENC[AES256_GCM,data:4+8fQ1hM80Z/zh4L3pjf,iv:TVG9vGE4+2klN/aecz4Z7uQjran14Nt8q70es/mLfVc=,tag:R5mPQjllBO7JfvLdBtF3dA==,type:str]
-                    - name: ENC[AES256_GCM,data:tZ/aZRuPM4y8dHnYfTB/7g==,iv:0UANr5bBgnCOiJEGRjAPQ2lmf8LOrYX+MlNllQljfY0=,tag:IzrGn8p5yf2HpwIL7Y8NTA==,type:str]
+                            key: ENC[AES256_GCM,data:/5oscYNmxr8=,iv:pWMjLuZ+72eveVVno8LgGNBn1V8h1pyrEQpx76dTsk8=,tag:lAg9WqLlev+d6IkOfxwzng==,type:str]
+                            name: ENC[AES256_GCM,data:2OqYSRqRCVKS72fFve9Q,iv:fAYGUfbcwEBovUWMG96FXtsLSFG/3CxRNaGJbqqdWCY=,tag:HuQPjIVyQ2amzUbdKgyBvQ==,type:str]
+                    - name: ENC[AES256_GCM,data:lZ3SrUBC6xuCAsijMqw1dg==,iv:AFn7zRXAh+gP4ibqwL8ZQATktb95ysvAPIfXHCFBXDs=,tag:PFvtIA5gh+sXAw7J/cAcZg==,type:str]
                       valueFrom:
                         secretKeyRef:
-                            key: ENC[AES256_GCM,data:yJd8n4YPtCk=,iv:oIIeflS2btigBO3+QpHdfAAcWzNPn8FZZHoB7/fLIo0=,tag:yEpkovQTtzyzfANOJ31vsQ==,type:str]
-                            name: ENC[AES256_GCM,data:4+8fQ1hM80Z/zh4L3pjf,iv:TVG9vGE4+2klN/aecz4Z7uQjran14Nt8q70es/mLfVc=,tag:R5mPQjllBO7JfvLdBtF3dA==,type:str]
-                  image: ENC[AES256_GCM,data:OTt9+auTx48ykYBGXO+1oQvy5ix/,iv:uqn/opS1OYnSoww/AXDOktvY8oDGGqlcQt1tNvOB/8k=,tag:ynhP3jPO2Qd9k0wjVoawuQ==,type:str]
+                            key: ENC[AES256_GCM,data:w6LVIGGOB7M=,iv:R+nGH6HDZ1GFwSwAB61jq7mdmAbBCgGy0URjzvPLXtg=,tag:AmWj0LxsUIcz8CYUurxckg==,type:str]
+                            name: ENC[AES256_GCM,data:Pwih0TbbWq2tSb5It1Ks,iv:MNZBDoLfh8cbsF+2gl24DeDngyQiWvnCO1escFpYtLQ=,tag:4qfwPR+a6yXlHUAwnOg42A==,type:str]
+                  image: ENC[AES256_GCM,data:Parx2fyibuKivN1h8fFKGLr85IK+,iv:cD699b57fP2iTjYAVTZrQoyxci3U14LhtBQTiVJ9RaU=,tag:+WBiEK7sqcjOgtsRv3+/8w==,type:str]
                   startupProbe:
-                    failureThreshold: ENC[AES256_GCM,data:CW8=,iv:c/VhzMz2tc82yfvV4Ldj35s9Psg/dF5qYWF0LoL54dM=,tag:AiW7MVR1GkJazrhQdB5UfA==,type:int]
+                    failureThreshold: ENC[AES256_GCM,data:w5c=,iv:QAYNaO1HlejXkkPWD7tfl8fpG+OeEVN6klWbclfVcNI=,tag:OIFp5uUrF5d+dJaShtCOUg==,type:int]
                     httpGet:
-                        path: ENC[AES256_GCM,data:hIVrk4PFRj7TEjGr2Lj/1G+C,iv:j51wdfic/9EGyW52CkmeXKtG8sDaoaVcK3hqu+qK4e8=,tag:V84yEDUB2yXTCMOzT9EXYA==,type:str]
-                        port: ENC[AES256_GCM,data:1ib5ww==,iv:owhxf+KdejWIOrgr5Q/6s5jVMz4SnJfiL6g4UbpY9oU=,tag:cj0r4XnOEiwDWp+S9NeOMQ==,type:int]
-                    periodSeconds: ENC[AES256_GCM,data:XKY=,iv:2t8PEk7yycUOsTCzzoeJOdw6ybu90RhjhBHyRiHDn/c=,tag:UAWJUZ9uqwhwofyo24xrsQ==,type:int]
+                        path: ENC[AES256_GCM,data:CwVRej6dTU0B4wNFDs1+p1vL,iv:QmvU8bhtijRU6NrpX8dBWJiu7twHsbtFu5yB5luuCq8=,tag:6d75sBY2cmXA+41X5ZC7uw==,type:str]
+                        port: ENC[AES256_GCM,data:rE3tSw==,iv:h+0d3FLDHKRJLXvAWp/BeottyecN71jpKoMTeVzh+38=,tag:dKgeA9Eijv/jWod+CbE0LQ==,type:int]
+                    periodSeconds: ENC[AES256_GCM,data:H4U=,iv:Yvd4AnfUPeX+KnOjP4g0ik2qUV3EWfP9FHlIHd0A5j4=,tag:xhq5JHh73gOVu5YiqIXvOQ==,type:int]
                   livenessProbe:
-                    failureThreshold: ENC[AES256_GCM,data:gQ==,iv:gbWiIi37GSVgJ2cusBghgQpvmQ2IGQg0Jp3uLgpjXNU=,tag:+4wc2mTdxPfhM3ZadsIgnA==,type:int]
-                    periodSeconds: ENC[AES256_GCM,data:1wo=,iv:5Up0GRa5U2a6wxAPixX7KO4Eja+ZK/dv49Idfqszqp0=,tag:8rX9Ym3a/RBdEvocpMVyOw==,type:int]
-                    timeoutSeconds: ENC[AES256_GCM,data:NEE=,iv:YKXKxvVMd6EKFvR0SmHTPb8kDqwxOY3WVtBrGyYjkPw=,tag:jRU+WTcp5pwBq2l/emJeJw==,type:int]
+                    failureThreshold: ENC[AES256_GCM,data:yw==,iv:o0F33NUTATbRq1wU/nwF+kBeQTfM8FhabifoFkcy8Hs=,tag:kuzJ6DtktDSPa9um7fw2zg==,type:int]
+                    periodSeconds: ENC[AES256_GCM,data:iQU=,iv:Q7PTSPMlaV/ciBmubcczz6xlq8dFaXWkFTCYJQKO0jQ=,tag:rX5AJ5sMNWyRZHa5RD8RsA==,type:int]
+                    timeoutSeconds: ENC[AES256_GCM,data:HOA=,iv:LfubBmCFBJiFgEiN7NXP9wyCvrm6VgMEDafcCxnabiY=,tag:0dobWQYvXPc45rcNYIixiQ==,type:int]
                     exec:
                         command:
-                            - ENC[AES256_GCM,data:FGc=,iv:Bj6KnwjcGJSAM4j/9Cg+PN69vaJKZ4aI2zLc/vxPXzQ=,tag:ajgKZar2OEauRwdnQY2y5A==,type:str]
-                            - ENC[AES256_GCM,data:0qU=,iv:6LUf3yEx1DqvdAsGIIHSakyKEzBJa2L65/JFZcvDWKE=,tag:DOH75HX6jJPv3ANsuvTYvQ==,type:str]
-                            - ENC[AES256_GCM,data:3KMOusUtDM1haGz120qoqhFWaAkKBMNbm3x+icWa5F3S/TdjYRLyLAc1jog0ImD7rSZJig4yN9/coQLs03MSqXxfbYaDZcDeGNyItbh4NUXgdYAjHR2Xv0CSKbvWSundexVX7PwkOQc5J7JDTrVPemHhX4WQ8pC7yACBu7AurwoUOrilfA==,iv:MAwstQTZbtcutia7jvM3AYBtG1LrUMIoCiVOBAVQTVo=,tag:GbveJvo5gCgneuDOUmorrQ==,type:str]
-                  name: ENC[AES256_GCM,data:dEMMi4lOqA==,iv:mUhaRueAskPfe9mOM8Ztgs+TdFKekEXdM0t8JrTFjFg=,tag:8kXk7EYdbvcx8uQLfk9j2w==,type:str]
+                            - ENC[AES256_GCM,data:KS0=,iv:H4hQMDTPC9SebONxu/wjM0x1aEYogvYDS5nm+XlRzhw=,tag:xFZf2vDqhU41jc4iYraeEg==,type:str]
+                            - ENC[AES256_GCM,data:TNY=,iv:2PA0wabkmPFc182Rq96EoYrc9UgMSigUuVDvAvNGAwc=,tag:IlCWovhotKptbuWZAbf4VQ==,type:str]
+                            - ENC[AES256_GCM,data:xmbmLhIbgbLC63NZjJV0w8Vm/oIKVxOGhQVB//3lCPGxExQmFRVqafOOoUgo0SXLcc30eqm+31agM/pB+b1j4ScNtMDOiCTUa0FMfFcGxPiBQa1jKoOt3JxmI02GVrAqjcfBHytGkSQhdm8OohSKOiqgH3ercu7YJQlnf/qPg5bTUlekkg==,iv:pcLEJeTOc0exiCRO+bs54pO05oM0LD2V43qpBleNRd8=,tag:Sd+Xg+S9fLgiE+c4F/IbXw==,type:str]
+                  name: ENC[AES256_GCM,data:v5q/smuzUA==,iv:WVwXmG3ypy8w/FZb6baIAbZyAP6qKniXJH97rL0tkMk=,tag:sPnjrk4Qw3JNbzW5eknlAw==,type:str]
                   ports:
-                    - containerPort: ENC[AES256_GCM,data:WdqmLg==,iv:s/1QgpVTxGNmHrfx1XVCI/N4Baw9O/gbB/5fMv7JNCI=,tag:jHXb+aAacZrYpeK7eZunIw==,type:int]
-                      name: ENC[AES256_GCM,data:CCoirbYURPsrtw==,iv:fywNCgavdC3tdQl1ytfTzNinxUJiZ7q0sRQwKjNstlo=,tag:x5ScE7Fc6rqSHCrv5iMxzQ==,type:str]
-                    - containerPort: ENC[AES256_GCM,data:DZdE+g==,iv:LT1SD7FIwcO/xVmq5Qxu33GOrO0NILr2OgN5S1bnai4=,tag:ptlOLEvgiVno/2j+w8nvyg==,type:int]
-                      name: ENC[AES256_GCM,data:ddUe1JVz,iv:WRNkP5/XUeo6ZDqmJhalP1iwxHBWPl9NgeJRZMdOiQs=,tag:CC2DqSTMm7r5aKAw2sPGZQ==,type:str]
+                    - containerPort: ENC[AES256_GCM,data:ncAOJA==,iv:zHScEk27hBYAwJnPuR13J9wkD1Dd1Fv1U72e166t5NE=,tag:cibIy415wGnW+5Y+DBZykA==,type:int]
+                      name: ENC[AES256_GCM,data:j3b0YZiTMbUzeQ==,iv:GLWgy10ggTBopQdxOtaqC5gIr/dNCYM81vIZwVOlGF4=,tag:ScsBlXjB9TPb7GPxT+/eXA==,type:str]
+                    - containerPort: ENC[AES256_GCM,data:OUA5aw==,iv:DAMrYaih+GPFbCVJnoslvvLKJoYzfAAN0cCXnoSjUC8=,tag:5R8jZ6Brw9V3vdNCaaArHg==,type:int]
+                      name: ENC[AES256_GCM,data:q6mOohKg,iv:KA4brW78aDIBJDdbZ74/PZQVKqF1jazlxjuplsLsvKI=,tag:4kU1pwfm4POTr5sEsEwJDg==,type:str]
+                  #ENC[AES256_GCM,data:N1jUYKlz0rWmLD6qGybzh9SIwZeFtXBlCAfHaYOAUP/4UGyZG/jjbkTdaP9FglQVcJVAmcostdLVjd1JImrmlGGKUg==,iv:bCrnmuV0K8BfJJVNkF4qcWckmiShUNUrOBhGko0u32Q=,tag:/OOVNSJXO8czPLPwXsRifw==,type:comment]
+                  #ENC[AES256_GCM,data:I8/ZtyIP4ky/wVDRni7zbD/XD+eUHMmrAW6H34zRz8KMfR6XmaJSwBJ65tqt/mQ5wg5w0nvm95+U2hIUyUBXKnyIzlf4Fw==,iv:7OnSkPwq/7Jj8YvW3u+fhxEr+4Y0emfrm0fcfoW//2w=,tag:8u9GE87+GiekL1S7r0XdtA==,type:comment]
+                  #ENC[AES256_GCM,data:9l0NQIjSu4m8IhvVcBD+sNNSapqi4gXoYCEjhIgtHMAASBQcIqVgULdTz7iM1HBrxcgRjIBLWHkIow+doERxLn4=,iv:lNKLzDm5hHwH6TrUK3t+BQSxBIdHWByX+DcFTLkO7zE=,tag:Y6rD0qSIDJWqCFYhcpg6Qw==,type:comment]
+                  #ENC[AES256_GCM,data:QVlOa22rs4FAc6s0W+UdOT1Ek3THJ2d6+WCw+l6/GEm5nEyyeFM13ewFW5OQE+ltvY3i5x0TjLmThu65qSMo7g1plx7M,iv:nX4vHkG8qj3v71QAam+Rlp0I4Eirz/nCw09WpGZ9cLE=,tag:ioE/pRxgTOoeD+uRP69dxQ==,type:comment]
                   readinessProbe:
-                    failureThreshold: ENC[AES256_GCM,data:+A==,iv:6OGUoqY1E8Xm0qkWdVodaBN4YJ1zd6HxfIY+HBPwHPE=,tag:Sd1gs0z/BBB9j22vmr3ahw==,type:int]
-                    periodSeconds: ENC[AES256_GCM,data:ups=,iv:44QjYAMe5xEDGWspdzdnqt2jxwTE9QPdD1feh66FA/0=,tag:TGNVb2ZACAgemDuQgj6tuw==,type:int]
-                    timeoutSeconds: ENC[AES256_GCM,data:DPU=,iv:hpoDFeBMoUkXM99gsca0JCyQpNARZbOXHFUn+cKnyFw=,tag:zIkfYPEW0tfOr+LeGgdi0w==,type:int]
+                    failureThreshold: ENC[AES256_GCM,data:0A==,iv:lLrlhnn3wg6g4fIi12STRyqHFBhlMIj/XBe7f2455MA=,tag:Omj4Bc0BuqvQvBKR7rajrA==,type:int]
+                    periodSeconds: ENC[AES256_GCM,data:1Rc=,iv:hdICoj9CKAaSqabh0DPNJpvOeGn+IOvjtyeaMpx2zG8=,tag:hKSIoEIDvqNmpP1QG53ETA==,type:int]
+                    timeoutSeconds: ENC[AES256_GCM,data:poM=,iv:TcuoqVGvU/9d7imfe9J5Ok+nUArW/wQRRE2/bW4ufuE=,tag:IPNX+S8BOGzP5znsQnNYkQ==,type:int]
                     exec:
                         command:
-                            - ENC[AES256_GCM,data:bNw=,iv:GkTfbhLf2KHuFT9tlboBCS1ENqr0rJqeli+XUhYj2IM=,tag:Fr1HAhE8AY6gAp0cwnjwDw==,type:str]
-                            - ENC[AES256_GCM,data:T9E=,iv:9yeGnf7LeZMK+fY2Li1afODlAXHr8ETpR9T7mB0rEQE=,tag:+82kxUcH/H5OAwpmrOIuBA==,type:str]
-                            - ENC[AES256_GCM,data:xjQcan3K/vkW+m5T7MWdIueF45pyvhSSakoMYff6GwAhP1EaxS9h+2zs3AxVkPHUIpeActpghZScl3E91l2L1uXIGjVgnaLRzSWSh95OBqrzmF5ygLsVDgeFAhE3P9icWGELe65mSq2UWCFeUt85oysUofma8BW8qTp3eNHTES/reH4U,iv:p/Cmv5RtIsKh9i6ui/2I9W5bwpXZ3WlhgS2sK8vH9Nw=,tag:quQXAXvt0w/hZB1/Wfj5Ng==,type:str]
+                            - ENC[AES256_GCM,data:w4o=,iv:lZ3lCCj+UcnSQQ11gYv7RbNXjlFc4mL8iRGFVZPZv2Q=,tag:C9sDeC7liZNww9YAKvCH5w==,type:str]
+                            - ENC[AES256_GCM,data:VQw=,iv:1d/8cY5tPdcuRh+Foj+QUZw+FPaiVF3kRYLt9GcKDHI=,tag:gv0uDaQyM9GqpChVVjAhtg==,type:str]
+                            - ENC[AES256_GCM,data:UjndqF9Bb+jIFTZIcUj2bHcR/tToT2vqaw6Skb0HlycphUPZV4RVonik2e4dv+Vb+AjTPkqD0odlBBl4LEqh0gI0EyYdFt2TdnZffDYF96kDgWt+d8u3g2nD3dNr+h1vWZ4wyCHY0Eg9ZvYs0g1U5RQoKl/4ysOaadL4cItTnNh40MwAkw==,iv:9sl68RJGgX6V/n2wAtmYg9VEmQEI7yKkfbqyINwKEcw=,tag:NRd8afsQ5Z3nqQtF0mOBPw==,type:str]
                   resources:
                     limits:
-                        cpu: ENC[AES256_GCM,data:4Q==,iv:tsLzzagBZYEi15ZFHef7z7Qw4b6haGAwukzw80beQ18=,tag:o6Ay1LYQn8lpvNFqzfbSCQ==,type:str]
-                        memory: ENC[AES256_GCM,data:Xj+nmIE=,iv:TufJHh0RQcVI4KkcyFKan09KhUKmHsi7TeftO2q8Hcw=,tag:umFTTv7XTvXMaFkbGzL+Gg==,type:str]
+                        cpu: ENC[AES256_GCM,data:+Q==,iv:bnbYGUHv0IvRhwPV2J69PpwafPLxcx27FmcZsbX5acw=,tag:h6jgOVV9AwGtw78jnRBI/g==,type:str]
+                        memory: ENC[AES256_GCM,data:ZoT3,iv:1S6sEhj1t6ZU95jR4KM7loBaKxsBpR7NYO+N/yo+6nU=,tag:0NO11IEI4gtMraC6hcNUag==,type:str]
                     requests:
-                        cpu: ENC[AES256_GCM,data:glEsDA==,iv:2tD73HDcp/Hq1b2Q5Q4pm0wviZm7Y/PNZIRhbig4rMQ=,tag:rBwpe0gi4mJ3NTjbgTKYdg==,type:str]
-                        memory: ENC[AES256_GCM,data:0jlaFdk=,iv:E3NZWo6y7Olpa0Qck+if+ec+qV1HV+Ex6zDOnMzpZpM=,tag:My3IvUnLuzwtQK+/Bzw+QA==,type:str]
+                        cpu: ENC[AES256_GCM,data:z/6LVA==,iv:/lQcBeGmnG7H+wjh3Yq3jhhcCJThvzlpXHsml4P23IQ=,tag:R8YJZceWm1eg478TCrTSsA==,type:str]
+                        memory: ENC[AES256_GCM,data:hy1uCVU=,iv:4G7f6tILPSODm7IaVMIl6swgGBOa9fjym5ByijbX7lA=,tag:q7+qmuRGyU0fnbNv27Dwwg==,type:str]
                   securityContext:
                     capabilities:
                         add:
-                            - ENC[AES256_GCM,data:CTMwziJVla11,iv:Yw/x600uXQbnx0L3hEB4hAHU2IFzaySW4Ht5z6uEHXI=,tag:t2ASftp4peWUiLylhnA7tA==,type:str]
+                            - ENC[AES256_GCM,data:3UMB15aj3xhe,iv:vq6p6SGjZhMrV9GCEQP2dhTn4J6PXljbblI03z5OH04=,tag:NbvNTmArOuTPJkfY9l1feg==,type:str]
                   volumeMounts:
-                    - mountPath: ENC[AES256_GCM,data:QjegnkOo/WuZBG0B,iv:Ih0ljz/4TtVXFx8Z1Gz9p4PRuhGIPTn59FdQgM97RwM=,tag:RGs/JsJq6Ottn7LXAnJ4GA==,type:str]
-                      name: ENC[AES256_GCM,data:EO4g,iv:a7gRL1i8FhUpifT/8PyVBKxQQ+uyjlr3tgyvoDfIjUU=,tag:mvmAfs7fnp01HuFnc5W1gw==,type:str]
+                    - mountPath: ENC[AES256_GCM,data:0UFh9P3M2caRwjnP,iv:B5Cg71sMFqTijNtPoh+zEtghdgs6k8f8tS4WNtJ9HLE=,tag:zTrTFEYg4997xqraJQs+hw==,type:str]
+                      name: ENC[AES256_GCM,data:8xTD,iv:GEfKKpmMgRQCFmFyJFv7VCuclQzmwiKATKqNTggpv9Q=,tag:mVwO7jKsetryjD8U4wDSPA==,type:str]
             nodeSelector:
-                kubernetes.io/arch: ENC[AES256_GCM,data:1W/sBv4=,iv:7RqGi55X+M1CROrY0p73tAYWEput7Ddio99v+C8FA88=,tag:VxjINH2R5lcb7LPysGPWzg==,type:str]
+                kubernetes.io/arch: ENC[AES256_GCM,data:n8F6aXc=,iv:ufHUAeU6Z8EskUeC8AQkY0gKHDwNZzBWCiSLebdxxTg=,tag:8kdtgws+ArIqn5yuv6nXkA==,type:str]
             volumes:
                 - hostPath:
-                    path: ENC[AES256_GCM,data:XAZdVdCBIumbChf/,iv:5LuHW51Ri1tlRVShGwzDbpCzVVDUUyTzgUleYnPLNPM=,tag:iRyKD5QiOsaMLgX0uukckg==,type:str]
-                    type: ENC[AES256_GCM,data:R1Bjaql8S1Dd4g==,iv:ljl5WBAGyggT/r9wEQbsP58MF5DR5g0pfF1amhfibUY=,tag:ckabwQn/7VGnwkprKTNDtA==,type:str]
-                  name: ENC[AES256_GCM,data:ADlm,iv:7H+BhudXJgCqC1quNw4ffvs8ix+4catoEwTtewdDHtI=,tag:GQ1jJCPH+sj0DwiUuFTUYQ==,type:str]
+                    path: ENC[AES256_GCM,data:/mw2yUkQYOPVqGfT,iv:/PyNz9OIHgxvEkGSZOHnAH4gc7wJ2JFB47MtPHL5pvo=,tag:GNGuHo8tsBB/Mv4WqpkUsA==,type:str]
+                    type: ENC[AES256_GCM,data:xjDvlyE+IsOXbQ==,iv:joFR/orslvWc+eVmtcTmZdE0ruqD3ISThFNZ7+R4gC8=,tag:iRBOMLEdHkSgsuRO8YGUHA==,type:str]
+                  name: ENC[AES256_GCM,data:cFdP,iv:IsofqiY9ZPOSEmUrrgZMc8qHaQahFDABHh/2S0AfUXs=,tag:DHZM7aPH23YOCvK/nSXhQQ==,type:str]
 sops:
     age:
         - recipient: age16krjysalsq26mfndnthd9r42thapj43a0zdndgrrz30utzuhwd0q7fxh9p
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYc0dEVXcyVThia0ZZeTQ0
-            UEx1elo4cTBKamdNMDA0TktCcGRBWGxLOUJBCk4vYkcwc1ZhaUY1ZURUOHBObUNt
-            TzRKb0pxaENwQnhCSFc0Q25DNjZPNzgKLS0tIDcyS2h4S1RyYllKQ0NmZjhlc3pn
-            UDY3Rmh5cXY5dUl5N1F1YThWRjFZN1kKHDxYZ+wyjOTmEIk5IrtWg0kojBxRPSgr
-            vnxZUV/Fi57/6kLH0PS0EzbSJ9RGxOL/ckC15c35UYCnaq8oBP3Ycw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0WXhHQlBkMlQ2eUlKUGJF
+            Nlh5VWIzT3MxbGVuYXJaYVoxZHpBSUtQZlE4CllYYVYxQ2xhd2xyd0pPZ3pYUmkw
+            OXR0bWMxVzcyQ1pPcmdheUJyRkhnTTgKLS0tIFR2MkRESjMvdGdoNUJYMEJIZEdX
+            VlZ5TC8zWkVvbmlPU01JSjRuSHVSUDQKSXg9l6nmH2annxrInN2Si0ZAgTH2Hdwz
+            3O5a0WfMwUbR9GSSEEChxyjqXPG1/xDXTo9stHC2IC08H3JzrHygGA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-31T16:02:48Z"
-    mac: ENC[AES256_GCM,data:pqmDXhGtntH5MT3SloEeV4sMCVSyn64639zoR1lGxU1CwexRaDhk1LtHtR7+7vzHKQXkJfPuyLBLqWlK6eCOi7+5YdISoh+NM/GKQ8VLU+MCPm9Q8FAdXoexUnVujR/aUT26ueVD8Ku14vtYVSUEfTovJqeJAm16/PSSaqrhzvo=,iv:6r6qEDDGb2VbOMj6LcjIoZPSULBaWYidjI1ShCkaQM8=,tag:seLIQoM+Nx+BGWWd45UhRA==,type:str]
-    encrypted_regex: ^(.*)$
+    lastmodified: "2026-07-26T03:06:37Z"
+    mac: ENC[AES256_GCM,data:qU3wsH/E8uYZtfbr+WuW3HJjqKOo+ik0RjRiX/oPHe4odUxNSp5hKlRXaupv2yi5ISj0L1QZnZSXMPov2KIjZu/vUk6MBlOzde0EeAXj+d9eIaqokYNywHz0AX+J1J4Jg/h68dV9Cbi7Coytm35KHU3t8q8hJwjztGurUoHyxPY=,iv:WrGa5foWdU7g3n2xCS7z55cLXdkS3SMyNvS/wltpKiA=,tag:pP83AaXffHJmxxgoO8FHhQ==,type:str]
+    unencrypted_suffix: _unencrypted
     version: 3.10.2
 ---
-apiVersion: ENC[AES256_GCM,data:Jno=,iv:RISkgaAcJruwNEtrQywOuyUgWheVepTSKyfthwqhi3c=,tag:J95x8s5NFdzwe61fD7mnnw==,type:str]
-kind: ENC[AES256_GCM,data:rkdDqT10/w==,iv:EjEDzzV7Iu8A7n8EKSkY06FRwxF+efTmq919hF9aWuY=,tag:S+PlSZ+VffZEj49UZ4brrw==,type:str]
+apiVersion: ENC[AES256_GCM,data:YTU=,iv:4TXIlQDC6D/uFdgmDLII0mxwsZO9V7S6tYgnv7oJwZU=,tag:sCWgrrEN/QDByn4YOTGZkQ==,type:str]
+kind: ENC[AES256_GCM,data:QPKqojnZiw==,iv:x95sxuzGmufFYHcbvBii26PTD1SRqBN4qH4Atn8s7zI=,tag:JQ3XqyVlsx+SDjQiQL8DrA==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:G9oRk4P7ALkI,iv:YyO2tNWW7yj6ylEGxLNMTgY/1kN5KWopDcrATdmdEYc=,tag:YO85L7CE+bNmurjabiEQDw==,type:str]
-    namespace: ENC[AES256_GCM,data:2Q2V31U=,iv:z8Gjgx6UOkKDE8UVYy8SynbAVwVK2HoyWX/TBOzG7pY=,tag:4JlUpb76bn6G4j5YfeTXRw==,type:str]
+    name: ENC[AES256_GCM,data:g/PQ9yeHvd9E,iv:hY6v38yBAEv8y00GPVSK4WjSV7HxZTsnkxF+cQgUwQw=,tag:QG3aViRmNehdF0AzUnWRDA==,type:str]
+    namespace: ENC[AES256_GCM,data:NBzC/nk=,iv:YH4DT8V9D8laZmW6T2U5HPA0mgCSYKoPpPbueF6ZIbk=,tag:jOfdUK/w+TR1YsTSNqtJAA==,type:str]
 spec:
     ports:
-        - name: ENC[AES256_GCM,data:/E2TXjXDOdiywQ==,iv:5wCOfjQe0pj6FUhuWPQeJEyGX3dJcT2JE77rufpiB6k=,tag:f4Eid3kyrPnV1tns1rnnFg==,type:str]
-          port: ENC[AES256_GCM,data:YThPgw==,iv:5g5kYPPiDcW/8iVQ+DYcn3/10tuKFzkOCEVErd1C5vo=,tag:Ph/vu/ydVkzaoRL83IvoIQ==,type:int]
-          targetPort: ENC[AES256_GCM,data:spFKjQ==,iv:4SMFI+CK4QP+nSy+EbdspaJybwQ7pWCeuFJLjy0oHik=,tag:bR/QI7AVpmczxrEC/S94+Q==,type:int]
-        - name: ENC[AES256_GCM,data:Y/FLNe1v,iv:I7TtJusCYteeFPtS7ggoEza6wl8slrLTn7tRi8fmqIA=,tag:+0X93Uy/wxBpJGzsBHTfVA==,type:str]
-          port: ENC[AES256_GCM,data:3QEfqA==,iv:iwU/jRmT9RDHk+pF4wCr0b/0RolSam7jiFNwzW++U7Y=,tag:2Q/ws/jgRsIEOml48j3ucg==,type:int]
-          targetPort: ENC[AES256_GCM,data:WmqT6A==,iv:CVykew+xdQBzEwuGnFFNL22T7Oe3xLDKGd1MZhP3+yY=,tag:ixPa6dwkf1G6WPcmY+QAtQ==,type:int]
+        - name: ENC[AES256_GCM,data:TJ8suUX7VtUO3w==,iv:zRA3acclAFyzukGgpL1N85scJ56GpQcT0YlmwbhO6nQ=,tag:91kY5Xi/81BerhrLcj6bYA==,type:str]
+          port: ENC[AES256_GCM,data:YGMS4Q==,iv:QhPexnsqBXRkRKt+Y1vylKLmRi95sKk4vwdiOqQJaVY=,tag:DqZesDnJFv+4Xj57F3K5cA==,type:int]
+          targetPort: ENC[AES256_GCM,data:yE6T4g==,iv:75N3gusF39vV2LKAsA8rbmCumGkAfIDVY7Egwg4G92Y=,tag:HRgQKre8ZVlrOJc9ubNJ3A==,type:int]
+        - name: ENC[AES256_GCM,data:cmpZr8I4,iv:TfhXCewAI2uS/6m4cQrrYcmpcQN/Im4ARcYMipLWbHY=,tag:YNBV217BX5HT2H4UHQEnYg==,type:str]
+          port: ENC[AES256_GCM,data:3W38Lg==,iv:UVV2sV+Tr/iZ51vUoS4tvyn6zJpdv5oyJQlamDieKt4=,tag:lFIUnhcAPITN/K/UOBM7tw==,type:int]
+          targetPort: ENC[AES256_GCM,data:1rygTg==,iv:zSxFoS4dN7UXwy+yiJSLLytdIHgITRxiU3AikGANHDQ=,tag:V3IVoXGO2nt0j1uiQeNFEA==,type:int]
     selector:
-        app: ENC[AES256_GCM,data:LxXBxXM3jC0B,iv:XkP5lGO3LNjqdE2q2iinKFrLu8dLlRFdT5j0UEinDoE=,tag:fsBD7UO2MCEF3gJxM4VM0Q==,type:str]
+        app: ENC[AES256_GCM,data:M+m0xNQeFFPK,iv:CZ6OXngFzuPVGreKTUzPMMCLYwY+DDjwCTJ3Xyr5RIc=,tag:UiajRVk/jLGiO+cZ7gYyMA==,type:str]
 sops:
     age:
         - recipient: age16krjysalsq26mfndnthd9r42thapj43a0zdndgrrz30utzuhwd0q7fxh9p
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYc0dEVXcyVThia0ZZeTQ0
-            UEx1elo4cTBKamdNMDA0TktCcGRBWGxLOUJBCk4vYkcwc1ZhaUY1ZURUOHBObUNt
-            TzRKb0pxaENwQnhCSFc0Q25DNjZPNzgKLS0tIDcyS2h4S1RyYllKQ0NmZjhlc3pn
-            UDY3Rmh5cXY5dUl5N1F1YThWRjFZN1kKHDxYZ+wyjOTmEIk5IrtWg0kojBxRPSgr
-            vnxZUV/Fi57/6kLH0PS0EzbSJ9RGxOL/ckC15c35UYCnaq8oBP3Ycw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0WXhHQlBkMlQ2eUlKUGJF
+            Nlh5VWIzT3MxbGVuYXJaYVoxZHpBSUtQZlE4CllYYVYxQ2xhd2xyd0pPZ3pYUmkw
+            OXR0bWMxVzcyQ1pPcmdheUJyRkhnTTgKLS0tIFR2MkRESjMvdGdoNUJYMEJIZEdX
+            VlZ5TC8zWkVvbmlPU01JSjRuSHVSUDQKSXg9l6nmH2annxrInN2Si0ZAgTH2Hdwz
+            3O5a0WfMwUbR9GSSEEChxyjqXPG1/xDXTo9stHC2IC08H3JzrHygGA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-31T16:02:48Z"
-    mac: ENC[AES256_GCM,data:pqmDXhGtntH5MT3SloEeV4sMCVSyn64639zoR1lGxU1CwexRaDhk1LtHtR7+7vzHKQXkJfPuyLBLqWlK6eCOi7+5YdISoh+NM/GKQ8VLU+MCPm9Q8FAdXoexUnVujR/aUT26ueVD8Ku14vtYVSUEfTovJqeJAm16/PSSaqrhzvo=,iv:6r6qEDDGb2VbOMj6LcjIoZPSULBaWYidjI1ShCkaQM8=,tag:seLIQoM+Nx+BGWWd45UhRA==,type:str]
-    encrypted_regex: ^(.*)$
+    lastmodified: "2026-07-26T03:06:37Z"
+    mac: ENC[AES256_GCM,data:qU3wsH/E8uYZtfbr+WuW3HJjqKOo+ik0RjRiX/oPHe4odUxNSp5hKlRXaupv2yi5ISj0L1QZnZSXMPov2KIjZu/vUk6MBlOzde0EeAXj+d9eIaqokYNywHz0AX+J1J4Jg/h68dV9Cbi7Coytm35KHU3t8q8hJwjztGurUoHyxPY=,iv:WrGa5foWdU7g3n2xCS7z55cLXdkS3SMyNvS/wltpKiA=,tag:pP83AaXffHJmxxgoO8FHhQ==,type:str]
+    unencrypted_suffix: _unencrypted
     version: 3.10.2

--- a/apps/media/media/01-proxy.sops.yaml
+++ b/apps/media/media/01-proxy.sops.yaml
@@ -1,170 +1,162 @@
-apiVersion: ENC[AES256_GCM,data:jfK20A0s8A==,iv:/EhR2RqUXlUsLSjQ2ciTDSNCVH3DP7jfsyGy8NWhLGY=,tag:U7XtlVdrGXFnhq2wMkuVQQ==,type:str]
-kind: ENC[AES256_GCM,data:X4bSOOG12Q7EIw==,iv:G9Q+lPpo56iwM/zeulQL3wwBAYeajIs09kat7Of+6nk=,tag:Tvtk3bYuosGwD9kiEykCww==,type:str]
+apiVersion: ENC[AES256_GCM,data:5HJWFmgjyQ==,iv:HGXI4wqrZb14eULig8+jPa1BG3sb+ZUq+kA8LKuTWFA=,tag:ARPRzDlq3b9Pgvm/arFz/g==,type:str]
+kind: ENC[AES256_GCM,data:zWmS6FFVkXOcYw==,iv:1/4bnqmuRLgSK0SQo9va6j5yuq1QbiW29/SsEkYuLB4=,tag:AjTYDQJn2iDSx73EVXnWqw==,type:str]
 metadata:
     labels:
-        app: ENC[AES256_GCM,data:H2hlWhYBrgHh,iv:m2baEFWf8IuDatwioaXVzNrl3howalCIIFd/DgBGegw=,tag:kcV9lL2su1LHWl1+qF1F+A==,type:str]
-    name: ENC[AES256_GCM,data:L0mPGiQTIODp,iv:tkAJBO5Lpe+LYkmCBOBxw3UWaICt1JhlJR/JNSKKfKk=,tag:FqNSdV8ZuoMO47dFJY1EBQ==,type:str]
-    namespace: ENC[AES256_GCM,data:Y1eOkEk=,iv:MLd3ORi5x90deObQp2lilHdidBQkjHiYAV1afSUgO+s=,tag:70SmAamj11cBcLIvzV0mlw==,type:str]
+        app: ENC[AES256_GCM,data:NUCci1X2eogb,iv:vOeyJEuzFqY1gpcbmLHIntLAX5RvCZEV5USdRElSoPM=,tag:+wL3iqr8VuciHaIpEKDZ+A==,type:str]
+    name: ENC[AES256_GCM,data:RB4tEa8FF2/7,iv:G1A0RzsoXate41IWKvJqMHzndgiqiiIhetNTXPiJtsI=,tag:i9AxtF4ubSP9yKV/jY3A0A==,type:str]
+    namespace: ENC[AES256_GCM,data:4mFtrL8=,iv:HhiN6CXcPAwKJL7o+i251888OHNGTu9mWiCTuJbb0F4=,tag:DqD2tFa4nGakrc3nwjCa0A==,type:str]
 spec:
-    replicas: ENC[AES256_GCM,data:9A==,iv:Q9rWt6gLRXPoa8wPqDu82Pcu/66m8VsBBhKoH+gtwHg=,tag:dTnhAMPOOUdcVhIfZ+tb/g==,type:int]
+    replicas: ENC[AES256_GCM,data:rw==,iv:Dnq91LCPtDZ40NOFgV3UXUzujw+lxeQQoevD9tZB28U=,tag:a3vWHHcJY2kLr4naX5AZDQ==,type:int]
     selector:
         matchLabels:
-            app: ENC[AES256_GCM,data:XBLZoFZBFxFb,iv:cSsF1kOvjO/JTZak4q2Sy+1i97phtSYsOeBVKfUDuBE=,tag:XlFtMvfSIf8LA2WKibAU7A==,type:str]
+            app: ENC[AES256_GCM,data:kbEDm7AlqDEC,iv:HtsSgQo9SCzsQSuXHuAohaRKWx1r8vlM6VMMF444T3Q=,tag:AkjFJpILliB3JNyTJJTRoA==,type:str]
     template:
         metadata:
             labels:
-                app: ENC[AES256_GCM,data:9077qLEQfFLo,iv:jGyu5NiEtS00dQVDBmo0t5T6hNFIyem7iQf1R0+n6EI=,tag:UHluLREH7SPACqECs7zEYQ==,type:str]
+                app: ENC[AES256_GCM,data:goCRScKpSaDA,iv:F0M1VL6D48CCOGYrDOUSIALXP0z+fsbT9JrYIg6aWsA=,tag:VVSdmoyBb7vORuuTzbk+BQ==,type:str]
         spec:
             affinity:
                 nodeAffinity:
                     requiredDuringSchedulingIgnoredDuringExecution:
                         nodeSelectorTerms:
                             - matchExpressions:
-                                - key: ENC[AES256_GCM,data:ttjFcId8UBA2PaAmZ7q4Dh0uohG9Lw==,iv:/53GLZ1seKDdYBm/68aMYy0LODkO1aQwkurhfobAiBg=,tag:cm93yJpTf4QwhM5aYSGtyQ==,type:str]
-                                  operator: ENC[AES256_GCM,data:XVBT+dc=,iv:qBN5M2rsO66jaQrZlyhnCTVCF2Z5uRXotpVNqtPKNI0=,tag:CigNhH1ujbP+T5BZ284PWA==,type:str]
+                                - key: ENC[AES256_GCM,data:lqZ1RfUCrSAmVOnQo9G5JpXGLWEYJA==,iv:6X/0SUrHXom3gXKlGTF3z3NJL9f1WhvqU77vZ1AUmmY=,tag:Nu7lLfvWraO2x/fR8HlhrQ==,type:str]
+                                  operator: ENC[AES256_GCM,data:ZLDkMMU=,iv:9ckB1Y92rFV4w/i8lVSqxi4YTNlwWlv0a9TW647e9lU=,tag:fRzUdYdRYg3v5G/21sC1ew==,type:str]
                                   values:
-                                    - ENC[AES256_GCM,data:K+VCxjeg8AV6gK7K,iv:DYGTN79kDGBPVeKj1LfqWyDYxnOnf4+ckVAOPHq9NoM=,tag:buJdb5feBo7lvPDeWHuVKw==,type:str]
+                                    - ENC[AES256_GCM,data:jvkHf6CYD/j/bntl,iv:VFLqIn/w4s5Ro6g71flnTyz3B42s8/QBNyfXDBtE15E=,tag:CANmqvTSIbg/Xv1xTZlUIQ==,type:str]
             containers:
                 - env:
-                    - name: ENC[AES256_GCM,data:nzy6Teq5xlhbd/2YIXr0A87vzpQ=,iv:YMmvuPBYKzDHAJtN+sia27hoSEVhS73N9oWFVqOsOT4=,tag:jeRnPdUBNK3MAqfXxRs6vw==,type:str]
-                      value: ENC[AES256_GCM,data:c8Veec4PafycqSUmfWeQZxiOcArxvmo=,iv:BN4DdNBLLKo6x4IuSDTMsY5NLzAC1bH7hWWpgqyGMhQ=,tag:yc8Gwo5ODyYn7QRKoIwymg==,type:str]
-                    - name: ENC[AES256_GCM,data:yWnyiHpSEu4=,iv:UqOn2LT7tE3o3Hby8JzP3jQpjyBf/m16E5UxvkQOyRw=,tag:OBxOIxCPZjKH3e3ZYHzV3g==,type:str]
-                      value: ENC[AES256_GCM,data:17yp7iih6Q==,iv:3xIoqvoJstgxRbTCXmk779Yyz/DCd6WtBlAXRxaRHOo=,tag:IgWMFBgi0jPkSeuIt9yZfA==,type:str]
-                    - name: ENC[AES256_GCM,data:Sw5e/GpHouMh2yuVp8A=,iv:AKBVSZQkUhKcM6eETWSHqr+fhXbh5hZSqRevdLWdNQk=,tag:wJjtItdk8rSt+ZpKTCs6LA==,type:str]
-                      value: ENC[AES256_GCM,data:6/QRj/j6bH1fUCwXfLMQqRsHX9w71r8dY2RJ0F74jEWOF42avtKe3e0sEAhTTfzssGiAMo31EF4r0LAG0intyeJPCcVrouUSNbi3XWHRCLFf8Qgksy45vatD/HInfPlxvOyT7uPwPXrQgdIyZ9j93X4kuj/PZysimaoV,iv:QhVEGGOpxDDAT5gyRGSy9rx8Os3IJEZ7R4K/GAd+HlM=,tag:+vriAacpRsD1hmCPjAkVNQ==,type:str]
-                    - name: ENC[AES256_GCM,data:EQ7vcgmoY6RGW9LyiDc=,iv:kq9URM/FCZZlGMEExxOQ2p+M8cgwihYeXPKPDRJAw/0=,tag:tqKJNw34CKL1gFCugJe+Hg==,type:str]
-                      value: ENC[AES256_GCM,data:4HYp,iv:VlOXBr8VS0ueNKnn7N16RO8LbhrnswNBSGqJfhKOqoo=,tag:Wofvt9M595HDDU0mCPtNlw==,type:str]
-                    - name: ENC[AES256_GCM,data:pTSqmJzq3irR,iv:GxGWhnNUg9kZ9z/jPl9xHt7UET9wwNIRG0/oRfGSJMo=,tag:+kYZP5Qcq1Co8YC18IaqSg==,type:str]
-                      value: ENC[AES256_GCM,data:eNs=,iv:/sWSlRIQ3dWv9D1jHahKAXQtW2AGbeY7xR1kFBjHI3w=,tag:RATNBgp5vGgnLdfKPe4Z9A==,type:str]
-                    - name: ENC[AES256_GCM,data:CHWY6KgAQjOGFcuAcQ==,iv:aElxGz8pQAaqi+WG6ZX27h1HWsZwtBnXsrE1MUUM0gM=,tag:yqJfKF13NGHUipY1MDdF2g==,type:str]
-                      value: ENC[AES256_GCM,data:IqOi,iv:ZlvRXmHULOPXbVTjDYDll9DWvdJUYBNro4CyqdsHxzw=,tag:z7FXQCyZOE32fj4QPUNvFA==,type:str]
-                    - name: ENC[AES256_GCM,data:5cosKYRj17izOXY=,iv:4qP3OmomsWOWK0o7zxlMg+owprIhwsDqckxUCDmhfDA=,tag:ep3coOgin2Ls2vhhWfoe0g==,type:str]
-                      value: ENC[AES256_GCM,data:X/1J,iv:WJ0r8uuM6scs5gybLTFUI4iPBz2cnqfN7cwMH4mJ/tk=,tag:luKa2OoxcM1ONf3d+UYHqA==,type:str]
-                    - ENC[AES256_GCM,data:29iegDA4gfEE4iKkVcmStHfaEnBhIL5I/+rvr6e8MEDRBr76awkrc1b1HiYZ419Bhw5SZorgnr1G/gshSKb2VlZz,iv:XO2dz/Ta6ynzRUvSEDMq+7wXjDlIacaCP10bS4zWz3o=,tag:aKHE3TRsLt7L3QJ7F42dKQ==,type:comment]
-                    - ENC[AES256_GCM,data:yUKI8Tel1FrwU2Gjun6YxaMRiEs4sp1JaQJXgi0bzdKcP9Rd3KaGpgyRbRT2rEX+uQY4QGFXm6TR4OJx8KdpIuvSbQ==,iv:1elM8FZl7yqk85VLKNt4BjvZVNLW4hGlq5S/Jur6MmE=,tag:1EMEaNYvD0NOm8V4qKvL4w==,type:comment]
-                    - ENC[AES256_GCM,data:VG8xtKutV0DTQ2D6aCo/oJBPeKIl8zaHzH9euzceKyD2tH+vyDRmVrIu+fNywqr8HTZRrBghRQOWfQxyoCI5G/Guik0=,iv:jT682PWScGKPLv1yNMN7EdBYvLPRGcAQVGRvSwF6y5o=,tag:5TGI5h7SZSF+/ZxqfulC8Q==,type:comment]
-                    - ENC[AES256_GCM,data:iIrvPw2aHZG5ApnDuFhBYmbb8fD8kMzdGAcK/t/0JLSAM7RrpPPDOSc1uWfmv7oDYplTdxyqopi4cE01oGVp5o/P/F0=,iv:uud9N7Clc6SsDPCPKpntnS/UnvcE/GPArYMlbbOQAY8=,tag:ri8k/8BVGlf4G5n08PshUQ==,type:comment]
-                    - name: ENC[AES256_GCM,data:Azr6W21skZ02F4eq6VaG,iv:xkznrNjj1mQdQ31Bc52XJlnfuC/lzi7JFMjy5buqRVc=,tag:p+Z9YeCVKraxcBUjiidrKg==,type:str]
-                      value: ENC[AES256_GCM,data:Vj/i,iv:jr2sxRDyHhGPqPjaE9FcrVp91+IpEOUfD4c4z6rUUbo=,tag:N8zt1vJkJNQVBgLdCS6LNA==,type:str]
-                    - name: ENC[AES256_GCM,data:PlrFuzQojx2W,iv:ci4dvvPDYsXmrnyBs2IQ+aKe+6kGMfFYJ3NGuvbGtDo=,tag:Flm+G/ZlykxyLpkeLU8W1A==,type:str]
-                      value: ENC[AES256_GCM,data:cAKG,iv:dpRKY3QqRWNLK9qaE9eOcNt6KaB9nQ/FiA1fADEFFeo=,tag:tAhpPoWkc4dnfyfKuIbETA==,type:str]
-                    - name: ENC[AES256_GCM,data:HryUzkAbF3PBiEeZxcPpcWOh,iv:Kr57DvLzYgMRwPVem9cjLv29bMPCM0kaehxNNJFuVNY=,tag:I/0kyz63RzTUOVYSQzPjXw==,type:str]
-                      value: ENC[AES256_GCM,data:Ep2O,iv:11qD1hxRs3GyErchM7J7nMXz/QJZ9fZ64ox1QuPxEtQ=,tag:64MwfAYIFHuvKN4McOj4Ug==,type:str]
-                    - name: ENC[AES256_GCM,data:JveW8l2LUEPzi5NR70Yq/J8=,iv:miNGrIniasyr+w0mV1OgNgrWY54G8nZFm6VUgQWc1rs=,tag:lwPDe0YI1LDSTCpTCMbGQA==,type:str]
-                      value: ENC[AES256_GCM,data:cQ==,iv:1Ey6ne5A6lNK/OQuoMH3+DUjVIGghZTvBFShFgHNKSU=,tag:LaeH2Tq1369Qc2ZFA0aLjQ==,type:str]
-                    - name: ENC[AES256_GCM,data:N6dapzrr4HognupRS3dG9tv7EDM=,iv:S6LF9Z33/zXTyDwqivfpx3RzGRJmOvqfgo7Fv16qL54=,tag:9aUPxOHOqUlmgHhACg1ovA==,type:str]
-                      value: ENC[AES256_GCM,data:jv8Y8X9kpngAxavGedY=,iv:VQK/4YVEZyD5sjfg80YrhaYdoElMPFDdLvD9qcz3e9c=,tag:yWeStA6fNKClwIe7lMH2/g==,type:str]
-                    - name: ENC[AES256_GCM,data:2EMTpYo1vBcnlq6STSqoutlfPYTPo0iivg==,iv:mpFC+DgcuS+zL5cTU3l5XGq9C/m0AL4uymkvFMmjJLY=,tag:+E0NL59QQ8T+kcTbxQnauA==,type:str]
-                      value: ENC[AES256_GCM,data:/xxU1NnuEc+cfVHccMpLJxfhJ8MWkRXZOjRT5IatwA30v1MDDZQa,iv:KqFLeNrhm50gt9RoDaCXGy2K30lGBPZdLyS1HBkJ3HU=,tag:L/Z2+UU0YkH81iyeeZRGzQ==,type:str]
-                    - name: ENC[AES256_GCM,data:a+d0OaZ6ta59uqck,iv:qq+UtLakThp8d4S9932YHkp+ITY+DoCi1ATYEoFiG7E=,tag:Dsv7BzphtinYtdMENG86vA==,type:str]
+                    - name: ENC[AES256_GCM,data:/YaNBHbxuJnFfoO44YhiI2HwC9A=,iv:Ip6roI4MV85DMLc60KRZhoy5Cq7eu2f/WIjcSAeqhfw=,tag:SJ1kdpF9aaLcMiQSu1ZDlg==,type:str]
+                      value: ENC[AES256_GCM,data:y+8tEtGutoBc2/3sbK6nnA+Ju7hTVls=,iv:5fUX/90lXZlF5n+m1WX86Bj+PosS6lvb2OQHyOeqaUM=,tag:5M2lNFb/aGO63gxodn6bVg==,type:str]
+                    - name: ENC[AES256_GCM,data:AZR/krBzdjE=,iv:UBSvwq2RrFruxXMviERyR8MPcHc329oYfFXgTArs+oU=,tag:Y3tOAvAfOiWnsaQLtbk7nQ==,type:str]
+                      value: ENC[AES256_GCM,data:IKeJ0b8XVQ==,iv:SSe6xailIKkQYdIXBlLUwAM0xfG7MsVxxLCm9rEXgEc=,tag:UokhCtOFGiCODVcBrJ4Bqw==,type:str]
+                    - name: ENC[AES256_GCM,data:ExXubWcBXveqZ2vHY4c=,iv:B1c0ZrJNnDgLrw3FK8GafsxfmZOH4EeIzQdN5mJQptU=,tag:7WFCW+cZodyKVj+8RCY4uw==,type:str]
+                      value: ENC[AES256_GCM,data:uxM7ByIOSnmC4fipRyzbRJYQhFmkjlwKwsnZpg+rHyteJmJ8fLm1NR32rGVvwlRGUz+FzSwjMVGPq7MEghOiOPU7ttipQj8KI4gddqbKlV6kbidQr5Zsx5BIkbC3YwKH1qU8VDJI1csLH8L7cC4swOvxp522jy6xC13q,iv:Lw6+1VT2dWWPCaSA9SqtJsjsNry3RFeZnnn7HR7eAU0=,tag:yakIXbi4OAtVqH56FlFMbw==,type:str]
+                    - name: ENC[AES256_GCM,data:2snpAnQBe12MsugoFfg=,iv:Oh6BFjG4j/dqWM/83Q212nRhk5PR23+KPi+fJyZjOU0=,tag:pUe+P/rI4Hox9bJfSQpp5g==,type:str]
+                      value: ENC[AES256_GCM,data:dNcf,iv:XHmqcF2qgB3/7gF5cTfM3M6Y7uAYfBFCWSJLJbUjB3c=,tag:D2zBURafuUEM7BhMvF2C/Q==,type:str]
+                    - name: ENC[AES256_GCM,data:NNxhOM8agamI,iv:AD79PFvVzm0AA3XNHHBkUxZtLGv6Pjm8BkWn4DK1lec=,tag:sk8BZBsh3kyT5+Kii9vBWw==,type:str]
+                      value: ENC[AES256_GCM,data:J/s=,iv:wnQUWJojBb+hjX9DT+k7YbKfwZEUyvmj0BGUk5zCp00=,tag:lc+EYOVMiHyt7Ki3XkUYGg==,type:str]
+                    - name: ENC[AES256_GCM,data:iVBwHULNO2FNQ+lrEw==,iv:dzCilfAPyEhoBFwqn2i+vRvBCgmZvvatsM8YdOF6/zM=,tag:YL3pXsqWc7eiiZH1MApw7w==,type:str]
+                      value: ENC[AES256_GCM,data:ZG6u,iv:yxnYXzj0+pHsj1FAXGpzMEV2z8+1dxFhBHHxPLCb8i8=,tag:EYsXzv2WRAYZURMv083uBQ==,type:str]
+                    - name: ENC[AES256_GCM,data:fNyrkGiy54+T1w8=,iv:E997YZvXEu2d2Cz/KWHwYWDW9c2ZpUFSWUAXMqqI/jw=,tag:CQc5fUxsl6py4Jp/P//KXQ==,type:str]
+                      value: ENC[AES256_GCM,data:5NwO,iv:taa66BcQ+E4KAOt0L75crqCSKZiTOIn6LsJ0eSltA9w=,tag:MMzSy7BHAWsOs1wZOPTJIA==,type:str]
+                    - name: ENC[AES256_GCM,data:2P582NGahKcuWrJd7NGg9sVTpo0=,iv:tamNIklVQQswvKB/M0PT7j8BuInocmQkSk6kjI7Sbrk=,tag:dqPC4UTpGC0ExMl63vV7iA==,type:str]
+                      value: ENC[AES256_GCM,data:WjIqXnlEPOHjSuf/+A0=,iv:Ritez4qymtxwFW0w7YcfcjQfPDg5AkCcBM+vpKocsAE=,tag:Pn/+JNAsUH7AT2AlKouoZg==,type:str]
+                    - name: ENC[AES256_GCM,data:AM8we6iDaNTOOVYxgdcBIfK4K8ueVgozIQ==,iv:H8JfAz6pWECTOqEs4ULKcTQIZOmtDPogb0+6aG7Yhak=,tag:0k7NHvSntlK3OXNwrwYxOQ==,type:str]
+                      value: ENC[AES256_GCM,data:zHY9IDPvjWrTXaIDe+w1dEjaq8OvQmJAScXjxxYZFkrIgQ7g54Nc,iv:hnPdkN+Jml5AVGqeUVvZtI9ZHyTH1La5B6gbJzc5Inc=,tag:H5vuUB48F33FUuJ5HKjVBQ==,type:str]
+                    - name: ENC[AES256_GCM,data:qUmF9/lQm4bjEqBc,iv:Xm2Yg0Sibs1xXOU1EtiViH54tW3kYMtSAjiTsCQDP44=,tag:R7V/z41VhcrE014BAywqOA==,type:str]
                       valueFrom:
                         secretKeyRef:
-                            key: ENC[AES256_GCM,data:/5oscYNmxr8=,iv:pWMjLuZ+72eveVVno8LgGNBn1V8h1pyrEQpx76dTsk8=,tag:lAg9WqLlev+d6IkOfxwzng==,type:str]
-                            name: ENC[AES256_GCM,data:2OqYSRqRCVKS72fFve9Q,iv:fAYGUfbcwEBovUWMG96FXtsLSFG/3CxRNaGJbqqdWCY=,tag:HuQPjIVyQ2amzUbdKgyBvQ==,type:str]
-                    - name: ENC[AES256_GCM,data:lZ3SrUBC6xuCAsijMqw1dg==,iv:AFn7zRXAh+gP4ibqwL8ZQATktb95ysvAPIfXHCFBXDs=,tag:PFvtIA5gh+sXAw7J/cAcZg==,type:str]
+                            key: ENC[AES256_GCM,data:V+Ky/bKM0ME=,iv:TcINvrBc0iGB/un1gY8cSIkbscbNeOXBq+Dbj/fCzD4=,tag:myGlJETUTbGh0UPUl5hTdA==,type:str]
+                            name: ENC[AES256_GCM,data:Tob1MNxmFiWeuDBuCMRN,iv:RG3np6YeHVlYowxMgHUmuxR299JI73WpRJYRVW0iFXY=,tag:+emz3B3EZE4e6T0OuSYOZQ==,type:str]
+                    - name: ENC[AES256_GCM,data:SNrcrtSY2M83+4xQmijwvQ==,iv:il2dc5wj0Pf0BQO8w0PkR52Nj7Z2UxAGgU1Ux9jyWDY=,tag:ufuFu/Ayf1OJq8AoLI9wqw==,type:str]
                       valueFrom:
                         secretKeyRef:
-                            key: ENC[AES256_GCM,data:w6LVIGGOB7M=,iv:R+nGH6HDZ1GFwSwAB61jq7mdmAbBCgGy0URjzvPLXtg=,tag:AmWj0LxsUIcz8CYUurxckg==,type:str]
-                            name: ENC[AES256_GCM,data:Pwih0TbbWq2tSb5It1Ks,iv:MNZBDoLfh8cbsF+2gl24DeDngyQiWvnCO1escFpYtLQ=,tag:4qfwPR+a6yXlHUAwnOg42A==,type:str]
-                  image: ENC[AES256_GCM,data:Parx2fyibuKivN1h8fFKGLr85IK+,iv:cD699b57fP2iTjYAVTZrQoyxci3U14LhtBQTiVJ9RaU=,tag:+WBiEK7sqcjOgtsRv3+/8w==,type:str]
+                            key: ENC[AES256_GCM,data:f2akghKV4KM=,iv:gePZw5djAQ9kvEye/8Xn0PlLQ+oTDi959twJT9VaK6g=,tag:Jn0JQYF1JfI/q/0Np8NZSA==,type:str]
+                            name: ENC[AES256_GCM,data:+JmnyNuirvOZdwXhIId/,iv:icfPqe1sylPzfNnT6cJvglzryaadyH0WrFXiM9/6jgg=,tag:RLYdf/PqiGU4a7hz3xRB3A==,type:str]
+                  image: ENC[AES256_GCM,data:ja9z2R46mgxXSfDLUXJu3FLJmy/K,iv:uPAmj5c/jqd/80zStcxgbbdofx6a7bxTCwBXLUHr/jA=,tag:KdXe517WyVZZNBAZZk0p/g==,type:str]
                   startupProbe:
-                    failureThreshold: ENC[AES256_GCM,data:w5c=,iv:QAYNaO1HlejXkkPWD7tfl8fpG+OeEVN6klWbclfVcNI=,tag:OIFp5uUrF5d+dJaShtCOUg==,type:int]
+                    failureThreshold: ENC[AES256_GCM,data:NX8=,iv:92XtxyJwQwJOxvZL3G5nMoOZ955jntGlKFHNh50tNlw=,tag:64OVCEjDaUq87jcETqHvYA==,type:int]
                     httpGet:
-                        path: ENC[AES256_GCM,data:CwVRej6dTU0B4wNFDs1+p1vL,iv:QmvU8bhtijRU6NrpX8dBWJiu7twHsbtFu5yB5luuCq8=,tag:6d75sBY2cmXA+41X5ZC7uw==,type:str]
-                        port: ENC[AES256_GCM,data:rE3tSw==,iv:h+0d3FLDHKRJLXvAWp/BeottyecN71jpKoMTeVzh+38=,tag:dKgeA9Eijv/jWod+CbE0LQ==,type:int]
-                    periodSeconds: ENC[AES256_GCM,data:H4U=,iv:Yvd4AnfUPeX+KnOjP4g0ik2qUV3EWfP9FHlIHd0A5j4=,tag:xhq5JHh73gOVu5YiqIXvOQ==,type:int]
+                        path: ENC[AES256_GCM,data:vy9CZrE0V4VUnotTHWoFwabj,iv:34AzvBdJp4kcLWHlQJvZgWzZSUcyFSd/s1cuIJKE/K8=,tag:037FF2kct5nzWLgtv+0ijw==,type:str]
+                        port: ENC[AES256_GCM,data:gXaVmA==,iv:h2eUq1JH5Z5gENKciN9admrHt0Yt9hFgToj7K5UTkTg=,tag:l0eWnqunPnSbwhrMTpFnmw==,type:int]
+                    periodSeconds: ENC[AES256_GCM,data:PiE=,iv:/D+momk1GRg45SdcSRFPjRfbgBq/LoJMmsdVU+R18lA=,tag:cNSV4IjBG3Lm9SEwtNHcYQ==,type:int]
                   livenessProbe:
-                    failureThreshold: ENC[AES256_GCM,data:yw==,iv:o0F33NUTATbRq1wU/nwF+kBeQTfM8FhabifoFkcy8Hs=,tag:kuzJ6DtktDSPa9um7fw2zg==,type:int]
-                    periodSeconds: ENC[AES256_GCM,data:iQU=,iv:Q7PTSPMlaV/ciBmubcczz6xlq8dFaXWkFTCYJQKO0jQ=,tag:rX5AJ5sMNWyRZHa5RD8RsA==,type:int]
-                    timeoutSeconds: ENC[AES256_GCM,data:HOA=,iv:LfubBmCFBJiFgEiN7NXP9wyCvrm6VgMEDafcCxnabiY=,tag:0dobWQYvXPc45rcNYIixiQ==,type:int]
+                    failureThreshold: ENC[AES256_GCM,data:gw==,iv:f8v1pa79pmVpXbi1QlaXzY9sxZnbsBhiZfN84EKgQtE=,tag:a93DQfPbWnhHRKCpPdT7cg==,type:int]
+                    periodSeconds: ENC[AES256_GCM,data:jQg=,iv:nf/HgfkkhzSMiDVXY0XhW0dBZnKhQZuQgBRUssFhnrA=,tag:br5YZWWLpljbuWuNlLUQtA==,type:int]
+                    timeoutSeconds: ENC[AES256_GCM,data:xTs=,iv:doF5shWEYnOKNCwrcnPMxKAsLQRbRI8esxWfRC3Qb+o=,tag:gGmLQS2Eenq8ui9xgEbljw==,type:int]
                     exec:
                         command:
-                            - ENC[AES256_GCM,data:KS0=,iv:H4hQMDTPC9SebONxu/wjM0x1aEYogvYDS5nm+XlRzhw=,tag:xFZf2vDqhU41jc4iYraeEg==,type:str]
-                            - ENC[AES256_GCM,data:TNY=,iv:2PA0wabkmPFc182Rq96EoYrc9UgMSigUuVDvAvNGAwc=,tag:IlCWovhotKptbuWZAbf4VQ==,type:str]
-                            - ENC[AES256_GCM,data:xmbmLhIbgbLC63NZjJV0w8Vm/oIKVxOGhQVB//3lCPGxExQmFRVqafOOoUgo0SXLcc30eqm+31agM/pB+b1j4ScNtMDOiCTUa0FMfFcGxPiBQa1jKoOt3JxmI02GVrAqjcfBHytGkSQhdm8OohSKOiqgH3ercu7YJQlnf/qPg5bTUlekkg==,iv:pcLEJeTOc0exiCRO+bs54pO05oM0LD2V43qpBleNRd8=,tag:Sd+Xg+S9fLgiE+c4F/IbXw==,type:str]
-                  name: ENC[AES256_GCM,data:v5q/smuzUA==,iv:WVwXmG3ypy8w/FZb6baIAbZyAP6qKniXJH97rL0tkMk=,tag:sPnjrk4Qw3JNbzW5eknlAw==,type:str]
+                            - ENC[AES256_GCM,data:Mvc=,iv:gmRFgYIdPKI9jFKphi4hKeJufPXzo3D0JMNWGIFKPXQ=,tag:TUUQQHNODcHH3qI6MKkxqg==,type:str]
+                            - ENC[AES256_GCM,data:2cw=,iv:KmdHHdQzCJsSKg75IkKQCUsop6vAZ4NbRnaag397kCY=,tag:C2k663R7vOrihRqlM29tIg==,type:str]
+                            - ENC[AES256_GCM,data:rYrvKBmq4Lzgy+2Sizq39XTYmLB/4ZKElhmU159U8EZl1vcC5frRtEouNfnLJRxY6yHn56GiCPcv34LjKsALwNCzhIPDKovCQRZm2nGe6Pj5M7hfG6x5PP2fZcMhHRpH5rb2XvqYA8i90UIs8RsYqFpmSOZwr40E2d2TGiDTZ4UPcxLi7w==,iv:jYSRlhznNJ/CXDoAgXlbpxiGeQGhdZ8G4dPA0iKS41Y=,tag:3EwctVjfobBmM3HhIva9Pg==,type:str]
+                  name: ENC[AES256_GCM,data:pmRraiOr5Q==,iv:4o6mY2UU9jheVu8uDabwSOtQ5PXCpKEh1ZJXdUf+pq0=,tag:nKupQJsdNASNPZZ9klPvnA==,type:str]
                   ports:
-                    - containerPort: ENC[AES256_GCM,data:ncAOJA==,iv:zHScEk27hBYAwJnPuR13J9wkD1Dd1Fv1U72e166t5NE=,tag:cibIy415wGnW+5Y+DBZykA==,type:int]
-                      name: ENC[AES256_GCM,data:j3b0YZiTMbUzeQ==,iv:GLWgy10ggTBopQdxOtaqC5gIr/dNCYM81vIZwVOlGF4=,tag:ScsBlXjB9TPb7GPxT+/eXA==,type:str]
-                    - containerPort: ENC[AES256_GCM,data:OUA5aw==,iv:DAMrYaih+GPFbCVJnoslvvLKJoYzfAAN0cCXnoSjUC8=,tag:5R8jZ6Brw9V3vdNCaaArHg==,type:int]
-                      name: ENC[AES256_GCM,data:q6mOohKg,iv:KA4brW78aDIBJDdbZ74/PZQVKqF1jazlxjuplsLsvKI=,tag:4kU1pwfm4POTr5sEsEwJDg==,type:str]
-                  #ENC[AES256_GCM,data:N1jUYKlz0rWmLD6qGybzh9SIwZeFtXBlCAfHaYOAUP/4UGyZG/jjbkTdaP9FglQVcJVAmcostdLVjd1JImrmlGGKUg==,iv:bCrnmuV0K8BfJJVNkF4qcWckmiShUNUrOBhGko0u32Q=,tag:/OOVNSJXO8czPLPwXsRifw==,type:comment]
-                  #ENC[AES256_GCM,data:I8/ZtyIP4ky/wVDRni7zbD/XD+eUHMmrAW6H34zRz8KMfR6XmaJSwBJ65tqt/mQ5wg5w0nvm95+U2hIUyUBXKnyIzlf4Fw==,iv:7OnSkPwq/7Jj8YvW3u+fhxEr+4Y0emfrm0fcfoW//2w=,tag:8u9GE87+GiekL1S7r0XdtA==,type:comment]
-                  #ENC[AES256_GCM,data:9l0NQIjSu4m8IhvVcBD+sNNSapqi4gXoYCEjhIgtHMAASBQcIqVgULdTz7iM1HBrxcgRjIBLWHkIow+doERxLn4=,iv:lNKLzDm5hHwH6TrUK3t+BQSxBIdHWByX+DcFTLkO7zE=,tag:Y6rD0qSIDJWqCFYhcpg6Qw==,type:comment]
-                  #ENC[AES256_GCM,data:QVlOa22rs4FAc6s0W+UdOT1Ek3THJ2d6+WCw+l6/GEm5nEyyeFM13ewFW5OQE+ltvY3i5x0TjLmThu65qSMo7g1plx7M,iv:nX4vHkG8qj3v71QAam+Rlp0I4Eirz/nCw09WpGZ9cLE=,tag:ioE/pRxgTOoeD+uRP69dxQ==,type:comment]
+                    - containerPort: ENC[AES256_GCM,data:eOjF6A==,iv:aPA/fjs9m2mhbChDrZOIzuMEBepDNmtBRYLczQtTTXU=,tag:e7LTheUgBfhyAuDPxjL29Q==,type:int]
+                      name: ENC[AES256_GCM,data:743eTUte3KPvrQ==,iv:TV4rSuYdcSu7DE2aYYU+KO/mdkVf1WkDiSTuZR71tO8=,tag:w1wYQZ+Vo2wmH2v1psrgyw==,type:str]
+                    - containerPort: ENC[AES256_GCM,data:lWFPFQ==,iv:pQH7hdYFiWhpCd2+sA1Dg90G4Y+O6x1pBxq7wrjfQ/k=,tag:NBrKUpC60Hrjv6dSD0SRmQ==,type:int]
+                      name: ENC[AES256_GCM,data:3EiaMN2C,iv:dAG3hxgu0SYQkhSsMTg6HVccni4xq3ZvPVNM0Q61+ig=,tag:qruAl1+qXXkBIj+EFKKtBA==,type:str]
                   readinessProbe:
-                    failureThreshold: ENC[AES256_GCM,data:0A==,iv:lLrlhnn3wg6g4fIi12STRyqHFBhlMIj/XBe7f2455MA=,tag:Omj4Bc0BuqvQvBKR7rajrA==,type:int]
-                    periodSeconds: ENC[AES256_GCM,data:1Rc=,iv:hdICoj9CKAaSqabh0DPNJpvOeGn+IOvjtyeaMpx2zG8=,tag:hKSIoEIDvqNmpP1QG53ETA==,type:int]
-                    timeoutSeconds: ENC[AES256_GCM,data:poM=,iv:TcuoqVGvU/9d7imfe9J5Ok+nUArW/wQRRE2/bW4ufuE=,tag:IPNX+S8BOGzP5znsQnNYkQ==,type:int]
+                    failureThreshold: ENC[AES256_GCM,data:iw==,iv:QtftZNwUh7Jf043kuNSWbZd693Cz/8Xo4F9uTWYtsD8=,tag:RhGDW7fiC2jncB5mpIYDeQ==,type:int]
+                    periodSeconds: ENC[AES256_GCM,data:wrY=,iv:dv9VqneCtphpS4VEnqOY7ND4qkD7TNX4dBGMSR4Vlzo=,tag:j/5hw7WjyohJhpu5RI9K3Q==,type:int]
+                    timeoutSeconds: ENC[AES256_GCM,data:cWo=,iv:5UN3plR/OhElJCOJwpbbNNcHEQ99RnZSaz058ECC/V0=,tag:EN7/pouBqKh8nHrhK8AOKg==,type:int]
                     exec:
                         command:
-                            - ENC[AES256_GCM,data:w4o=,iv:lZ3lCCj+UcnSQQ11gYv7RbNXjlFc4mL8iRGFVZPZv2Q=,tag:C9sDeC7liZNww9YAKvCH5w==,type:str]
-                            - ENC[AES256_GCM,data:VQw=,iv:1d/8cY5tPdcuRh+Foj+QUZw+FPaiVF3kRYLt9GcKDHI=,tag:gv0uDaQyM9GqpChVVjAhtg==,type:str]
-                            - ENC[AES256_GCM,data:UjndqF9Bb+jIFTZIcUj2bHcR/tToT2vqaw6Skb0HlycphUPZV4RVonik2e4dv+Vb+AjTPkqD0odlBBl4LEqh0gI0EyYdFt2TdnZffDYF96kDgWt+d8u3g2nD3dNr+h1vWZ4wyCHY0Eg9ZvYs0g1U5RQoKl/4ysOaadL4cItTnNh40MwAkw==,iv:9sl68RJGgX6V/n2wAtmYg9VEmQEI7yKkfbqyINwKEcw=,tag:NRd8afsQ5Z3nqQtF0mOBPw==,type:str]
+                            - ENC[AES256_GCM,data:j08=,iv:kVnuHyzvfMSjxVoQZRj8w1CQM/oMTHyEkmOd5fnB9gg=,tag:nNRm7IvrUmN+YXDsP3rrSA==,type:str]
+                            - ENC[AES256_GCM,data:3X8=,iv:C1vUeF7tr5JqdAFRABZ0B/QVpkWTIoE2Jo/AOydckKA=,tag:b7QC8Xmgl8FSn9Wb2x3WdA==,type:str]
+                            - ENC[AES256_GCM,data:PPOnMPtiLqX+JCpoCz2BJCIM43M2TwKpPKmLaQOx2Zp2pq1HKnsYuDSOTFr5AokB1uU9tXDpL+rYV+BAdBPRecH2FiDATzgJqb6demwVBOOkj9WBg8Te8Uk0BnCYSvdbrOXry7UMmejaitSeoHEltOlIbpXUudUG8vEc9xXPJ3pgjWzB,iv:wG7Ic8x3NmpwRtUdg3gw3qUkvQasYtDxNG/bbqnK3ME=,tag:KbMCVu461nkms52S2sicjg==,type:str]
+                  #ENC[AES256_GCM,data:7dmsZQcNAsgV0DG+fE5/+Am+SstNLrnxeMY0Tg4C7dM1yW6M81HLmIozzQuPqR+FfXvHEDnOKKR88IwKtktQngc=,iv:+rlrYpuMAJZAL+A35NEESaGBInu276lF8EDL5GrVkR4=,tag:sC6I5m4khgdSOoOImkl+YQ==,type:comment]
+                  #ENC[AES256_GCM,data:yJ9FBS4IxiYDTQxFdZ3FtHkkuPF/SmagWt1JXuTnNmxih1d9bTTA7aPdJ3Oa5EN+INj+/TH29Guv/4T5LperQ1LyuA==,iv:ml7TSbMIUtW/ikpPTSh3GPizwIsY12VBq1wc3ERz5jM=,tag:G/yEzG5ZuAX3j3l5dIk7mg==,type:comment]
+                  #ENC[AES256_GCM,data:2t4oyUXBcidVkWPWJhPkjGLRazzkRBrx24AGWX1nn6CKwny69pmeRc6y3QDYBV2BTzxFR9lkRCFCmNfzM1QWq0NNqg==,iv:zS5lVWvoGA4MptfZLKHTjveADqSHb4u6hqxrt+OLWCg=,tag:1iWt0BYfRaDoJ3UIw86Y9A==,type:comment]
+                  #ENC[AES256_GCM,data:RI3AIhyk+5t+Sjtbpl1qbsG3HtUoZ82zOHOjqGjUs0cyuiJ9e0MlhK7yNL0RTTOVR34XtaZmq2YwDdYQaMN2B+nbGA==,iv:XR2ReQdnirhACetlDfW8VmuW/jYe+/le10VxU678P+w=,tag:NSke8ajoLQTnZXKj6/XQrQ==,type:comment]
+                  #ENC[AES256_GCM,data:WX5LgyUSqKmRWwrJtw8+j8pSAOyYB3aQL7ggj2/2X6AK/csg2GVPIhGgHMV3ojL/dv3WIz/Js4GIP/UyLnpag1a/ftT7,iv:DvsQSoaNQgCmv/8vzf8+9vHBShBVItEJSW6JeMqYOPA=,tag:r/rIjFLaekLXLrlqI4kblw==,type:comment]
+                  #ENC[AES256_GCM,data:RWOqoJggT0WnNas+kZhksRara40YUTYmxpAglm74MeU8gHm7collqmzJNW1f1kQbAmHKHI5PN5aGXOOpI2jnfy15Pw==,iv:3qWcs2htdLkrivu6KmxuTOB9EBntWRaCyp3poCxN05c=,tag:w73gLA6eRsjyp4yICF0K7w==,type:comment]
+                  #ENC[AES256_GCM,data:XnmcofL+mhAaFo/HIUfJWdArnxflY8z7DmWO401R1ierxA2tXuXs/pi69BnkmRlKpIJeqCdZdDDcBQOmMPODiCM=,iv:83VubkVZCgzpg6d+oNAwnkg8dmPaqlGFMiB53NhR604=,tag:/DFfh5JwX3wjarCtKWnB5g==,type:comment]
+                  #ENC[AES256_GCM,data:CBr4YG6SFTfZ+S5D9PGZnQ2mCJv9gwrHQwzY8bop3Gt2Zs12cqniXFJwZTUfIRDMPw==,iv:wvNUJVV/ZLdvEpydUKrAthvfFrW9XKWPLcWEdNvO1VQ=,tag:Wme8O8r5MwMSMMzwEP7m3g==,type:comment]
                   resources:
                     limits:
-                        cpu: ENC[AES256_GCM,data:+Q==,iv:bnbYGUHv0IvRhwPV2J69PpwafPLxcx27FmcZsbX5acw=,tag:h6jgOVV9AwGtw78jnRBI/g==,type:str]
-                        memory: ENC[AES256_GCM,data:ZoT3,iv:1S6sEhj1t6ZU95jR4KM7loBaKxsBpR7NYO+N/yo+6nU=,tag:0NO11IEI4gtMraC6hcNUag==,type:str]
+                        cpu: ENC[AES256_GCM,data:Mw==,iv:7B3JlUPDVHuqynYQXo1zHY8l7L6jc0rSsdpJlFG/0yA=,tag:Q2kFV3iyeq8m8oRoRCb5+Q==,type:str]
+                        memory: ENC[AES256_GCM,data:Du1y,iv:IOUEpOJH5vcrHlmT1N6T7L7afAOPXALbuDjeI3mdHJI=,tag:VR27rvRnOXMDgYaDvepwXQ==,type:str]
                     requests:
-                        cpu: ENC[AES256_GCM,data:z/6LVA==,iv:/lQcBeGmnG7H+wjh3Yq3jhhcCJThvzlpXHsml4P23IQ=,tag:R8YJZceWm1eg478TCrTSsA==,type:str]
-                        memory: ENC[AES256_GCM,data:hy1uCVU=,iv:4G7f6tILPSODm7IaVMIl6swgGBOa9fjym5ByijbX7lA=,tag:q7+qmuRGyU0fnbNv27Dwwg==,type:str]
+                        cpu: ENC[AES256_GCM,data:kXkk+w==,iv:DDlya/PRfSvFvD2DVcWvynNpW5VZ5eHtA6n14q6FrUo=,tag:WpKfAMediHNQ07O8C/cnXA==,type:str]
+                        memory: ENC[AES256_GCM,data:5s5shj0=,iv:HDouWjmrL0UcvOkBJ4cLGze+5Y2YF0LE+Y6tmGtzslI=,tag:Q7edTmgg1crYdmqIzGb4GQ==,type:str]
                   securityContext:
                     capabilities:
                         add:
-                            - ENC[AES256_GCM,data:3UMB15aj3xhe,iv:vq6p6SGjZhMrV9GCEQP2dhTn4J6PXljbblI03z5OH04=,tag:NbvNTmArOuTPJkfY9l1feg==,type:str]
+                            - ENC[AES256_GCM,data:r43C8qBiBJ0L,iv:eEW9gYKFEabgYu9sl1Wnp5yKnn1tectC0PT538cUBVM=,tag:0IXS2MTFpp2igmsVJwYvlQ==,type:str]
                   volumeMounts:
-                    - mountPath: ENC[AES256_GCM,data:0UFh9P3M2caRwjnP,iv:B5Cg71sMFqTijNtPoh+zEtghdgs6k8f8tS4WNtJ9HLE=,tag:zTrTFEYg4997xqraJQs+hw==,type:str]
-                      name: ENC[AES256_GCM,data:8xTD,iv:GEfKKpmMgRQCFmFyJFv7VCuclQzmwiKATKqNTggpv9Q=,tag:mVwO7jKsetryjD8U4wDSPA==,type:str]
+                    - mountPath: ENC[AES256_GCM,data:v3wFLkniYYigwbVu,iv:dhm08zxGXuZOuUbWkHr1WMfQsIG2UmKCq35Z2w03zsc=,tag:I+CwbdiIK8wEN2iGh5fPVg==,type:str]
+                      name: ENC[AES256_GCM,data:MwZl,iv:dkzJlvHHLgdkuPdf2YnyVVlzt1eYyXN+jcBCC3+2ces=,tag:WxAZtLoQKrYA7ybo6uMvNQ==,type:str]
             nodeSelector:
-                kubernetes.io/arch: ENC[AES256_GCM,data:n8F6aXc=,iv:ufHUAeU6Z8EskUeC8AQkY0gKHDwNZzBWCiSLebdxxTg=,tag:8kdtgws+ArIqn5yuv6nXkA==,type:str]
+                kubernetes.io/arch: ENC[AES256_GCM,data:q4lo/dM=,iv:M+1p0GivuJnEf58nSxVnY0SyjdCPFFgCq9++WOndicQ=,tag:+e0Vj348TKwy3lN+qEYwWw==,type:str]
             volumes:
                 - hostPath:
-                    path: ENC[AES256_GCM,data:/mw2yUkQYOPVqGfT,iv:/PyNz9OIHgxvEkGSZOHnAH4gc7wJ2JFB47MtPHL5pvo=,tag:GNGuHo8tsBB/Mv4WqpkUsA==,type:str]
-                    type: ENC[AES256_GCM,data:xjDvlyE+IsOXbQ==,iv:joFR/orslvWc+eVmtcTmZdE0ruqD3ISThFNZ7+R4gC8=,tag:iRBOMLEdHkSgsuRO8YGUHA==,type:str]
-                  name: ENC[AES256_GCM,data:cFdP,iv:IsofqiY9ZPOSEmUrrgZMc8qHaQahFDABHh/2S0AfUXs=,tag:DHZM7aPH23YOCvK/nSXhQQ==,type:str]
+                    path: ENC[AES256_GCM,data:/WJgXV1Zje8iv09t,iv:qYCl28rnj0JO9VWf2oAl0ofxTXpUQZmQxCtwzLtXPps=,tag:tkEQLlhjvrloDuyDwec+kQ==,type:str]
+                    type: ENC[AES256_GCM,data:QIudgAtEcLdorw==,iv:BSHNaRnTL0FE8u1ROyDPddxG9w1YdMAEXIbTRlNEPvE=,tag:UW4EpjBJTn1eNmhtBUzlmQ==,type:str]
+                  name: ENC[AES256_GCM,data:6FhC,iv:20zl2duXZbyGDzsnD/IJC4SjgZGQPWHv8xsLgkN4eYY=,tag:nZagHRNPzAHLK1c3Lq866A==,type:str]
 sops:
     age:
         - recipient: age16krjysalsq26mfndnthd9r42thapj43a0zdndgrrz30utzuhwd0q7fxh9p
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0WXhHQlBkMlQ2eUlKUGJF
-            Nlh5VWIzT3MxbGVuYXJaYVoxZHpBSUtQZlE4CllYYVYxQ2xhd2xyd0pPZ3pYUmkw
-            OXR0bWMxVzcyQ1pPcmdheUJyRkhnTTgKLS0tIFR2MkRESjMvdGdoNUJYMEJIZEdX
-            VlZ5TC8zWkVvbmlPU01JSjRuSHVSUDQKSXg9l6nmH2annxrInN2Si0ZAgTH2Hdwz
-            3O5a0WfMwUbR9GSSEEChxyjqXPG1/xDXTo9stHC2IC08H3JzrHygGA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVL2huTXBhN214MkY2V1VL
+            ZXhWOWFtcUt6SGZlU2NpRWdhWHRpNkNKeXc4ClRQRTVSOWJFdG5HMTRVL2hqVzVT
+            TVNzaHJKMEZWb0N4M3pGZENLS0NjWmcKLS0tIGhjREpHeVV4YVM0ajg1VlNCY09G
+            TXB6L0xRZkNWdUgvaVJLWVAwK1h3ajgKUhBhR2GDd8AgHGm/r4zY4LMb8CQ6mKOm
+            xK/rA3vFrviXnc/VXL3EcquREMujjBJQ1HUe4qTTnumD0KrzHbfxnA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-07-26T03:06:37Z"
-    mac: ENC[AES256_GCM,data:qU3wsH/E8uYZtfbr+WuW3HJjqKOo+ik0RjRiX/oPHe4odUxNSp5hKlRXaupv2yi5ISj0L1QZnZSXMPov2KIjZu/vUk6MBlOzde0EeAXj+d9eIaqokYNywHz0AX+J1J4Jg/h68dV9Cbi7Coytm35KHU3t8q8hJwjztGurUoHyxPY=,iv:WrGa5foWdU7g3n2xCS7z55cLXdkS3SMyNvS/wltpKiA=,tag:pP83AaXffHJmxxgoO8FHhQ==,type:str]
+    lastmodified: "2026-07-26T03:24:44Z"
+    mac: ENC[AES256_GCM,data:P5irY5qGOa7rvf9pdWr4eaEO8fVS16AvvBpNFdbrgZU2Zf7Bn7JwOrT9gK/46q+ZtUqvMtKxAIOMv6GsdHnTu8Ikp2Sl1jD8DljLfzLf5rxnlMuqmkTq8qAqlWmZ3YwMvm6eC4gJxQD9DPtoU8tvWOlZh/ltp45W0OCbGZReS58=,iv:3iWrNcvXJrpH+my2cKfXL2t9c2bA7WWmXT1HBe/B27s=,tag:6bCwoHa6N07jRx8qfC64vQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.10.2
 ---
-apiVersion: ENC[AES256_GCM,data:YTU=,iv:4TXIlQDC6D/uFdgmDLII0mxwsZO9V7S6tYgnv7oJwZU=,tag:sCWgrrEN/QDByn4YOTGZkQ==,type:str]
-kind: ENC[AES256_GCM,data:QPKqojnZiw==,iv:x95sxuzGmufFYHcbvBii26PTD1SRqBN4qH4Atn8s7zI=,tag:JQ3XqyVlsx+SDjQiQL8DrA==,type:str]
+apiVersion: ENC[AES256_GCM,data:q1g=,iv:4UFWIi0GuUL9KvLiRdUg+Fyqk3L0Ck1eNzvZdJFhirg=,tag:N0BImujqVIxuwdDTjtGaCA==,type:str]
+kind: ENC[AES256_GCM,data:t3+R8lXHhg==,iv:vg4QRfq7kEAwrz5yuVxfDts8BC/CIFJIoHZMMLNS/JE=,tag:stSAakIH/Mwk2pWwGRlT1g==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:g/PQ9yeHvd9E,iv:hY6v38yBAEv8y00GPVSK4WjSV7HxZTsnkxF+cQgUwQw=,tag:QG3aViRmNehdF0AzUnWRDA==,type:str]
-    namespace: ENC[AES256_GCM,data:NBzC/nk=,iv:YH4DT8V9D8laZmW6T2U5HPA0mgCSYKoPpPbueF6ZIbk=,tag:jOfdUK/w+TR1YsTSNqtJAA==,type:str]
+    name: ENC[AES256_GCM,data:wsbNYAIFlxkP,iv:XuoicVPEVYvKbVDRchIUvEgBaEyLJ13Ii9aUHjR5I5U=,tag:NxCC6lF3h0Iul8/K+l6asQ==,type:str]
+    namespace: ENC[AES256_GCM,data:LjLdY/I=,iv:vSZE4pnEQeDapGUQjjwFTLx17Oh03wpQQwpHvvP4gs4=,tag:VA7TJRocgW/xDruP5R0vHQ==,type:str]
 spec:
     ports:
-        - name: ENC[AES256_GCM,data:TJ8suUX7VtUO3w==,iv:zRA3acclAFyzukGgpL1N85scJ56GpQcT0YlmwbhO6nQ=,tag:91kY5Xi/81BerhrLcj6bYA==,type:str]
-          port: ENC[AES256_GCM,data:YGMS4Q==,iv:QhPexnsqBXRkRKt+Y1vylKLmRi95sKk4vwdiOqQJaVY=,tag:DqZesDnJFv+4Xj57F3K5cA==,type:int]
-          targetPort: ENC[AES256_GCM,data:yE6T4g==,iv:75N3gusF39vV2LKAsA8rbmCumGkAfIDVY7Egwg4G92Y=,tag:HRgQKre8ZVlrOJc9ubNJ3A==,type:int]
-        - name: ENC[AES256_GCM,data:cmpZr8I4,iv:TfhXCewAI2uS/6m4cQrrYcmpcQN/Im4ARcYMipLWbHY=,tag:YNBV217BX5HT2H4UHQEnYg==,type:str]
-          port: ENC[AES256_GCM,data:3W38Lg==,iv:UVV2sV+Tr/iZ51vUoS4tvyn6zJpdv5oyJQlamDieKt4=,tag:lFIUnhcAPITN/K/UOBM7tw==,type:int]
-          targetPort: ENC[AES256_GCM,data:1rygTg==,iv:zSxFoS4dN7UXwy+yiJSLLytdIHgITRxiU3AikGANHDQ=,tag:V3IVoXGO2nt0j1uiQeNFEA==,type:int]
+        - name: ENC[AES256_GCM,data:t4EXMspcXZuQDA==,iv:hpaMxKrpaBYNJ98tJ0uy1t5/va5sJlhXM0y8m4LKfxQ=,tag:QpEteufErwD2AxHIm/Gb8Q==,type:str]
+          port: ENC[AES256_GCM,data:kCm//g==,iv:+KvcSWIwoWjv5zRGJGZZAk4SwvpvCoD9BCIbZOBKEN4=,tag:Ecj9+dLFnn7BoLyo5+NjUg==,type:int]
+          targetPort: ENC[AES256_GCM,data:agmD+g==,iv:+TVdxI9feAx92h2C3yc4UxoAMs7MGjKbZZGnzcxmpxk=,tag:lDwp4a8u9RKQ148IEGKHpw==,type:int]
+        - name: ENC[AES256_GCM,data:rhk+ooQi,iv:z49tzvJWwx8VFIOXhYmwS+apEIrDunqHFbgdgBrjH00=,tag:OCj4IwGokPzPnfC9gqe2rw==,type:str]
+          port: ENC[AES256_GCM,data:XD5NWw==,iv:ZgUq81CNAaJMCO3sSKZb4SDRjkW414S6izN3svNgnpY=,tag:aBdxnkHaiMQMik85SYXXpQ==,type:int]
+          targetPort: ENC[AES256_GCM,data:lZPlyQ==,iv:p12cB2Xywr7Tg8+xYREyOCJcnFrYhv67qvbSAqw9RX4=,tag:8tsEOhjoozQR/2i6eDlH0g==,type:int]
     selector:
-        app: ENC[AES256_GCM,data:M+m0xNQeFFPK,iv:CZ6OXngFzuPVGreKTUzPMMCLYwY+DDjwCTJ3Xyr5RIc=,tag:UiajRVk/jLGiO+cZ7gYyMA==,type:str]
+        app: ENC[AES256_GCM,data:xaAir+cPsVRH,iv:2wg1J1BOpVXNSanDJS+t13TcA6cU+7u3O5dgMI110BA=,tag:cYkR/Z6OqnEWHzckwKx//Q==,type:str]
 sops:
     age:
         - recipient: age16krjysalsq26mfndnthd9r42thapj43a0zdndgrrz30utzuhwd0q7fxh9p
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0WXhHQlBkMlQ2eUlKUGJF
-            Nlh5VWIzT3MxbGVuYXJaYVoxZHpBSUtQZlE4CllYYVYxQ2xhd2xyd0pPZ3pYUmkw
-            OXR0bWMxVzcyQ1pPcmdheUJyRkhnTTgKLS0tIFR2MkRESjMvdGdoNUJYMEJIZEdX
-            VlZ5TC8zWkVvbmlPU01JSjRuSHVSUDQKSXg9l6nmH2annxrInN2Si0ZAgTH2Hdwz
-            3O5a0WfMwUbR9GSSEEChxyjqXPG1/xDXTo9stHC2IC08H3JzrHygGA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVL2huTXBhN214MkY2V1VL
+            ZXhWOWFtcUt6SGZlU2NpRWdhWHRpNkNKeXc4ClRQRTVSOWJFdG5HMTRVL2hqVzVT
+            TVNzaHJKMEZWb0N4M3pGZENLS0NjWmcKLS0tIGhjREpHeVV4YVM0ajg1VlNCY09G
+            TXB6L0xRZkNWdUgvaVJLWVAwK1h3ajgKUhBhR2GDd8AgHGm/r4zY4LMb8CQ6mKOm
+            xK/rA3vFrviXnc/VXL3EcquREMujjBJQ1HUe4qTTnumD0KrzHbfxnA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-07-26T03:06:37Z"
-    mac: ENC[AES256_GCM,data:qU3wsH/E8uYZtfbr+WuW3HJjqKOo+ik0RjRiX/oPHe4odUxNSp5hKlRXaupv2yi5ISj0L1QZnZSXMPov2KIjZu/vUk6MBlOzde0EeAXj+d9eIaqokYNywHz0AX+J1J4Jg/h68dV9Cbi7Coytm35KHU3t8q8hJwjztGurUoHyxPY=,iv:WrGa5foWdU7g3n2xCS7z55cLXdkS3SMyNvS/wltpKiA=,tag:pP83AaXffHJmxxgoO8FHhQ==,type:str]
+    lastmodified: "2026-07-26T03:24:44Z"
+    mac: ENC[AES256_GCM,data:P5irY5qGOa7rvf9pdWr4eaEO8fVS16AvvBpNFdbrgZU2Zf7Bn7JwOrT9gK/46q+ZtUqvMtKxAIOMv6GsdHnTu8Ikp2Sl1jD8DljLfzLf5rxnlMuqmkTq8qAqlWmZ3YwMvm6eC4gJxQD9DPtoU8tvWOlZh/ltp45W0OCbGZReS58=,iv:3iWrNcvXJrpH+my2cKfXL2t9c2bA7WWmXT1HBe/B27s=,tag:6bCwoHa6N07jRx8qfC64vQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.10.2

--- a/apps/media/media/12-vpn-proxy-watchdog.yaml
+++ b/apps/media/media/12-vpn-proxy-watchdog.yaml
@@ -32,6 +32,35 @@ roleRef:
   kind: Role
   name: vpn-proxy-watchdog
 ---
+# The media namespace is default-deny egress and nothing here opened a path to
+# the Kubernetes API, so the watchdog could see a wedged proxy but its restart
+# PATCH to kubernetes.default.svc always timed out -- every run ended in
+# `URLError: <urlopen error timed out>` and the self-heal never actually fired.
+# Egress policy is evaluated after the ClusterIP is DNAT'd, so the real
+# control-plane endpoints behind the `kubernetes` Service are what must be
+# allowed; the ClusterIP is listed too for CNIs that evaluate pre-DNAT.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-watchdog-to-apiserver
+  namespace: media
+spec:
+  podSelector:
+    matchLabels:
+      app: vpn-proxy-watchdog
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - ipBlock: {cidr: 10.99.5.10/32}
+        - ipBlock: {cidr: 10.99.5.11/32}
+        - ipBlock: {cidr: 10.99.5.14/32}
+      ports:
+        - {protocol: TCP, port: 6443}
+    - to:
+        - ipBlock: {cidr: 10.43.0.1/32}
+      ports:
+        - {protocol: TCP, port: 443}
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -47,6 +76,9 @@ spec:
       backoffLimit: 0
       ttlSecondsAfterFinished: 600
       template:
+        metadata:
+          labels:
+            app: vpn-proxy-watchdog
         spec:
           restartPolicy: Never
           serviceAccountName: vpn-proxy-watchdog

--- a/apps/misc/searxng/10-configmap-settings.yaml
+++ b/apps/misc/searxng/10-configmap-settings.yaml
@@ -18,8 +18,11 @@ data:
         - json
 
     outgoing:
-      request_timeout: 6.0
-      max_request_timeout: 12.0
+      # Every engine request takes an extra hop through the VPN proxy, so a 6s
+      # budget tripped on normal tunnel latency and returned "engine timeout"
+      # for engines that were actually fine.
+      request_timeout: 10.0
+      max_request_timeout: 15.0
       # Every outbound engine request egresses ONLY through the media VPN proxy
       # (gluetun/PIA). The NetworkPolicy enforces this at L3; this makes SearXNG
       # itself use the tunnel rather than failing closed on every search.


### PR DESCRIPTION
## Symptom

searxng returned `engine timeout` for every engine at once, while the searxng pod itself looked healthy.

## What was actually wrong

Not searxng. The `vpn-proxy` **Service had zero endpoints**, despite a `Running` pod matching its selector:

```
$ kubectl get endpoints -n media vpn-proxy
NAME        ENDPOINTS   AGE
vpn-proxy               87d
```

Everything in the cluster that reaches the internet through that proxy lost its path out at the same time.

The pod behind it had degenerated:

| | fresh canary | production (6h uptime) |
|---|---|---|
| CPU | **0%** | **99%** (223657/225482 periods throttled) |
| Memory | **58Mi** | **448Mi** (OOMKilled at 512Mi, 20 restarts) |

...while the tunnel was moving about **1 KB/s**. The tunnel itself was fine throughout — direct egress returned the PIA exit IP and a raw `CONNECT` returned `200 OK`. Starved that hard, the readiness probe couldn't finish inside its budget, so the pod was pulled from the EndpointSlice.

### The block lists were innocent

My first theory was gluetun's DNS block lists. A second canary running production's **exact** config — block lists on — also sat at **0% CPU / 58Mi**. So the block lists are not the cause; gluetun v3.41.1 simply degenerates over hours of uptime. v3.41.1 is already the latest release, so there is nothing to bump to.

That rules out the `BLOCK_*` / `DNS_UPDATE_PERIOD` changes I first pushed, and it rules out raising the CPU limit — a bigger limit just hands more of node-13 (already at 99% of allocatable CPU requests) to a spinning process. Both are reverted in the second commit.

### Why it never recovered on its own

There is already a watchdog CronJob for exactly this. **It has never worked.** The media namespace is default-deny egress with no rule permitting the Kubernetes API, so every run detected the wedge, tried to PATCH the deployment, and died:

```
urllib.error.URLError: <urlopen error timed out>
```

Confirmed directly — a pod in `media` hitting `10.43.0.1:443` times out at 10s (curl exit 28). The watchdog has been failing silently every 3 minutes.

## Changes

- **`allow-watchdog-to-apiserver`** NetworkPolicy + a label on the CronJob pods to select. Canal enforces egress *after* the ClusterIP is DNAT'd, so the allow names the real control-plane endpoints behind the `kubernetes` Service (`10.99.5.10/.11/.14:6443`); the ClusterIP is listed too for CNIs that evaluate pre-DNAT.
- **Memory ceiling 512Mi → 1Gi** so the leak stops being an OOMKill mid-request and the watchdog gets to recycle the pod on its own terms. **CPU limit stays at 1.**
- **searxng engine budget 6s → 10s** — every engine request takes an extra hop through the proxy.

## On the two invariants

Both were already correct in git and are unchanged:

- **DNS is in Technitium** — `searxng.internal.white.fm A 10.99.5.110` is in `35-zones-secret.sops.yaml` and resolves from both VIPs.
- **VPN handles egress** — searxng's namespace is default-deny egress allowing only cluster DNS, valkey, and `vpn-proxy:8888/1080`, and `settings.yml` routes `all://` through the proxy.

Deliberately **not** repointing gluetun's own resolver at Technitium: `allow-technitium-dnscrypt-to-vpn` shows Technitium's dnscrypt-proxy egresses *through* `vpn-proxy:1080`, so that would create a bootstrap circular dependency between DNS and the tunnel.

## Verification

- Deleted the wedged pod; the replacement went `Ready` with `endpointReady=true`, and a live search returned **18 real results** — the timeouts are gone.
- `kustomize build` clean on both overlays; image still pinned to `v3.41.1`; SOPS file round-trips fully encrypted.
- The watchdog NetworkPolicy is the one piece **not** validated live (creating it was blocked in my session). Its next run after merge will say either `k8s API: HTTP 200 — rollout-restart triggered` or time out again.

## Known limitation, not addressed here

With the proxy healthy, engines now **respond** rather than time out, but duckduckgo and startpage return CAPTCHA and brave rate-limits quickly — the usual result of routing search through a shared datacenter VPN IP. That is a separate question about engine selection (or pointing the CAPTCHA-walled ones at the FlareSolverr instance already running in `media`), and it is a preference call rather than a bug fix, so I left it alone.